### PR TITLE
Check file owner username using more generic way

### DIFF
--- a/blazingcache-services/src/main/resources/bin/service
+++ b/blazingcache-services/src/main/resources/bin/service
@@ -228,7 +228,7 @@ checkuser() {
     CHECK_FILE=$BASE_DIR
   fi
 
-  if [ "`stat -c %U "$CHECK_FILE"`" != "$WANTED_USER" ]; then
+  if [ "`ls -dl "$CHECK_FILE" | awk '{ print $3 }'`" != "$WANTED_USER" ]; then
     echo "Trying to run as '$WANTED_USER', yet $CHECK_FILE is not owned by '$WANTED_USER'. Exiting"
     exit 1
   fi


### PR DESCRIPTION
`stat -c %U` is a GNU extension. So it doesn't supported in BSD or MacOS. `ls -dl` is supported in any UNIX.