### PR TITLE
Rename CacheEntry to EntryHandle.

### DIFF
--- a/blazingcache-core/src/main/java/blazingcache/client/EntryHandle.java
+++ b/blazingcache-core/src/main/java/blazingcache/client/EntryHandle.java
@@ -28,17 +28,18 @@ import io.netty.buffer.Unpooled;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.SoftReference;
-import java.util.Arrays;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Una entry nella cache
+ * An handle to an entry.
+ * <p>
+ * Entries are reference counted so you have to call explicitly {@link #close() }
+ * in order to release the resources associated to the entry.
  *
  * @author enrico.olivelli
  */
 @SuppressFBWarnings({"EI_EXPOSE_REP2", "EI_EXPOSE_REP"})
-public final class CacheEntry implements AutoCloseable {
+public final class EntryHandle implements AutoCloseable {
 
     private long lastGetTime;
     private final long putTime;
@@ -57,7 +58,7 @@ public final class CacheEntry implements AutoCloseable {
      * @param expiretime
      * @param deserialized
      */
-    CacheEntry(RawString key, long lastGetTimeNanos, ByteBuf serializedData, long expiretime, Object deserialized) {
+    EntryHandle(RawString key, long lastGetTimeNanos, ByteBuf serializedData, long expiretime, Object deserialized) {
         this.key = key;
         this.lastGetTime = lastGetTimeNanos;
         this.putTime = lastGetTimeNanos;
@@ -136,7 +137,7 @@ public final class CacheEntry implements AutoCloseable {
         // copy data from Direct Memory to Heap
         return ByteBufUtil.getBytes(buf);
     }
-    private static final Logger LOG = Logger.getLogger(CacheEntry.class.getName());
+    private static final Logger LOG = Logger.getLogger(EntryHandle.class.getName());
 
     public long getExpiretime() {
         return expiretime;

--- a/blazingcache-core/src/main/java/blazingcache/client/EntryHandle.java
+++ b/blazingcache-core/src/main/java/blazingcache/client/EntryHandle.java
@@ -28,7 +28,6 @@ import io.netty.buffer.Unpooled;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.SoftReference;
-import java.util.logging.Logger;
 
 /**
  * An handle to an entry.
@@ -137,7 +136,6 @@ public final class EntryHandle implements AutoCloseable {
         // copy data from Direct Memory to Heap
         return ByteBufUtil.getBytes(buf);
     }
-    private static final Logger LOG = Logger.getLogger(EntryHandle.class.getName());
 
     public long getExpiretime() {
         return expiretime;
@@ -145,7 +143,7 @@ public final class EntryHandle implements AutoCloseable {
 
     @Override
     public String toString() {
-        return "CacheEntry{" + "key=" + key + ", lastGetTime=" + lastGetTime + ", expiretime=" + expiretime + '}';
+        return "EntryHandle{" + "key=" + key + ", lastGetTime=" + lastGetTime + ", expiretime=" + expiretime + '}';
     }
 
     // only for tests

--- a/blazingcache-core/src/test/java/blazingcache/FetchTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/FetchTest.java
@@ -7,7 +7,7 @@ package blazingcache;
 
 import java.nio.charset.StandardCharsets;
 import blazingcache.client.CacheClient;
-import blazingcache.client.CacheEntry;
+import blazingcache.client.EntryHandle;
 import blazingcache.network.ServerHostData;
 import blazingcache.network.netty.NettyCacheServerLocator;
 import blazingcache.server.CacheServer;
@@ -59,15 +59,15 @@ public class FetchTest {
 
                 client1.put("pippo", data, 0);
 
-                CacheEntry _remoteLoaded;
-                try (CacheEntry remoteLoad = client2.fetch("pippo");) {
+                EntryHandle _remoteLoaded;
+                try (EntryHandle remoteLoad = client2.fetch("pippo");) {
                     assertNotNull(remoteLoad);
                     Assert.assertArrayEquals(data, remoteLoad.getSerializedData());
                     _remoteLoaded = remoteLoad;
                 }
 
                 // same fetch, hits local cache
-                try (CacheEntry remoteLoad = client2.fetch("pippo");) {
+                try (EntryHandle remoteLoad = client2.fetch("pippo");) {
                     assertSame(remoteLoad, _remoteLoaded);
                     Assert.assertArrayEquals(data, remoteLoad.getSerializedData());
                 }

--- a/blazingcache-core/src/test/java/blazingcache/LockBasicTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/LockBasicTest.java
@@ -7,7 +7,7 @@ package blazingcache;
 
 import java.nio.charset.StandardCharsets;
 import blazingcache.client.CacheClient;
-import blazingcache.client.CacheEntry;
+import blazingcache.client.EntryHandle;
 import blazingcache.client.KeyLock;
 import blazingcache.network.ServerHostData;
 import blazingcache.network.netty.NettyCacheServerLocator;
@@ -54,7 +54,7 @@ public class LockBasicTest {
                     public void run() {
                         try {
                             waiting.set(true);
-                            CacheEntry remoteLoad = client2.fetch("pippo");
+                            EntryHandle remoteLoad = client2.fetch("pippo");
                             assertTrue(remoteLoad != null);
                             waiting.set(false);
                         } catch (Throwable t) {

--- a/blazingcache-core/src/test/java/blazingcache/LockLostTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/LockLostTest.java
@@ -7,7 +7,7 @@ package blazingcache;
 
 import java.nio.charset.StandardCharsets;
 import blazingcache.client.CacheClient;
-import blazingcache.client.CacheEntry;
+import blazingcache.client.EntryHandle;
 import blazingcache.client.KeyLock;
 import blazingcache.network.ServerHostData;
 import blazingcache.network.netty.NettyCacheServerLocator;

--- a/blazingcache-core/src/test/java/blazingcache/client/ConcurrentFetchAndInvalidationTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/ConcurrentFetchAndInvalidationTest.java
@@ -93,7 +93,7 @@ public class ConcurrentFetchAndInvalidationTest {
 
                 Thread slow_fetch = new Thread(() -> {
                     try {
-                        CacheEntry entry = client2.fetch("entry");
+                        EntryHandle entry = client2.fetch("entry");
                         System.out.println("FETCH RETURNED " + entry);
                         actions.add("FETCH-RETURNED");
                     } catch (InterruptedException err) {
@@ -123,7 +123,7 @@ public class ConcurrentFetchAndInvalidationTest {
                 System.out.println("key_client2:" + cacheServer.getCacheStatus().getKeysForClient(client2.getClientId()));
 
                 // THIS OPERATION SURELY HAPPENED AFTER THE INVALIDATION, SO IT MUST RETURN null!!
-                CacheEntry now = client2.get("entry");
+                EntryHandle now = client2.get("entry");
                 System.out.println("NOW: " + now);
                 System.out.println("actions:" + actions);
                 int actionIndex = 0;

--- a/blazingcache-core/src/test/java/blazingcache/client/ErrorOnFetchTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/ErrorOnFetchTest.java
@@ -72,7 +72,7 @@ public class ErrorOnFetchTest {
 
                 client1.put("lost-fetch", data, 0);
 
-                CacheEntry remoteLoad = client2.fetch("lost-fetch");
+                EntryHandle remoteLoad = client2.fetch("lost-fetch");
                 assertTrue(remoteLoad == null);
 
             }
@@ -111,7 +111,7 @@ public class ErrorOnFetchTest {
 
                 client1.put("lost-fetch", data, 0);
 
-                CacheEntry remoteLoad = client2.fetch("lost-fetch");
+                EntryHandle remoteLoad = client2.fetch("lost-fetch");
                 assertTrue(remoteLoad == null);
 
             }

--- a/blazingcache-core/src/test/java/blazingcache/client/HammerTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/HammerTest.java
@@ -71,7 +71,7 @@ public class HammerTest {
                                 String _key = "key" + j;
                                 byte[] expectedData = _key.getBytes(StandardCharsets.UTF_8);
 
-                                try (CacheEntry entry = client2.fetch(_key);) {
+                                try (EntryHandle entry = client2.fetch(_key);) {
                                     assertNotNull("key " + _key + " not found?", entry);
                                     assertArrayEquals(entry.getSerializedData(), expectedData);
                                 }

--- a/blazingcache-core/src/test/java/blazingcache/client/LockOnLostFetchMessageAndSlowClientTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/LockOnLostFetchMessageAndSlowClientTest.java
@@ -83,7 +83,7 @@ public class LockOnLostFetchMessageAndSlowClientTest {
                     public void run() {
                         try {
                             latch_before_2.countDown();
-                            CacheEntry remoteLoad = client2.fetch("lost-fetch");
+                            EntryHandle remoteLoad = client2.fetch("lost-fetch");
                             assertTrue(remoteLoad == null);
                             latch_2.countDown();
                         } catch (Throwable t) {
@@ -105,7 +105,7 @@ public class LockOnLostFetchMessageAndSlowClientTest {
                     public void run() {
                         try {
                             latch_before_3.countDown();
-                            CacheEntry remoteLoad = client3.fetch("lost-fetch");
+                            EntryHandle remoteLoad = client3.fetch("lost-fetch");
                             assertTrue(remoteLoad == null);
                             latch_3.countDown();
                         } catch (Throwable t) {

--- a/blazingcache-core/src/test/java/blazingcache/client/LockOnLostFetchMessageTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/LockOnLostFetchMessageTest.java
@@ -82,7 +82,7 @@ public class LockOnLostFetchMessageTest {
                     public void run() {
                         try {
                             latch_before_2.countDown();
-                            CacheEntry remoteLoad = client2.fetch("lost-fetch");
+                            EntryHandle remoteLoad = client2.fetch("lost-fetch");
                             assertTrue(remoteLoad == null);
                             latch_2.countDown();
                         } catch (Throwable t) {
@@ -104,7 +104,7 @@ public class LockOnLostFetchMessageTest {
                     public void run() {
                         try {
                             latch_before_3.countDown();
-                            CacheEntry remoteLoad = client3.fetch("lost-fetch");
+                            EntryHandle remoteLoad = client3.fetch("lost-fetch");
                             assertTrue(remoteLoad == null);
                             latch_3.countDown();
                         } catch (Throwable t) {

--- a/blazingcache-core/src/test/java/blazingcache/client/LostFetchMessageAutoCloseClientTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/LostFetchMessageAutoCloseClientTest.java
@@ -85,7 +85,7 @@ public class LostFetchMessageAutoCloseClientTest {
                     public void run() {
                         try {
                             latch_before.countDown();
-                            CacheEntry remoteLoad = client2.fetch("lost-fetch");
+                            EntryHandle remoteLoad = client2.fetch("lost-fetch");
                             assertTrue(remoteLoad == null);
                             latch.countDown();
                         } catch (Throwable t) {

--- a/blazingcache-core/src/test/java/blazingcache/client/LostFetchMessageTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/LostFetchMessageTest.java
@@ -85,7 +85,7 @@ public class LostFetchMessageTest {
                     public void run() {
                         try {
                             latch_before.countDown();
-                            CacheEntry remoteLoad = client2.fetch("lost-fetch");
+                            EntryHandle remoteLoad = client2.fetch("lost-fetch");
                             assertTrue(remoteLoad == null);
                             latch.countDown();
                         } catch (Throwable t) {

--- a/blazingcache-core/src/test/java/blazingcache/client/ReferencesTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/ReferencesTest.java
@@ -102,7 +102,7 @@ public class ReferencesTest {
                 assertEquals(2, countObjectWrites.get());
                 assertEquals(1, countObjectReads.get());
 
-                CacheEntry entry = client1.get(key);
+                EntryHandle entry = client1.get(key);
                 entry.discardInternalCachedObject();
                 entry.close();
 

--- a/blazingcache-jcache/src/main/java/blazingcache/jcache/BlazingCacheCache.java
+++ b/blazingcache-jcache/src/main/java/blazingcache/jcache/BlazingCacheCache.java
@@ -16,7 +16,7 @@
 package blazingcache.jcache;
 
 import blazingcache.client.CacheClient;
-import blazingcache.client.CacheEntry;
+import blazingcache.client.EntryHandle;
 import blazingcache.client.CacheException;
 import blazingcache.client.KeyLock;
 import java.io.InputStream;
@@ -184,7 +184,7 @@ public class BlazingCacheCache<K, V> implements Cache<K, V> {
                 throw new javax.cache.CacheException(error);
             }
         } else {
-            CacheEntry result = client.get(serializedKey);
+            EntryHandle result = client.get(serializedKey);
             if (result != null) {
                 try {
                     return (V) valuesSerializer.deserialize(
@@ -272,7 +272,7 @@ public class BlazingCacheCache<K, V> implements Cache<K, V> {
                 }
                 hit = resultObject != null;
             } else {
-                CacheEntry result;
+                EntryHandle result;
                 if (usefetch) {
                     result = client.fetch(serializedKey, lock);
                 } else {
@@ -356,7 +356,7 @@ public class BlazingCacheCache<K, V> implements Cache<K, V> {
                         hit = true;
                     }
                 } else {
-                    CacheEntry result;
+                    EntryHandle result;
                     if (usefetch) {
                         result = client.fetch(serializedKey);
                     } else {
@@ -431,7 +431,7 @@ public class BlazingCacheCache<K, V> implements Cache<K, V> {
     }
 
     private boolean _containsKey(String serializedKey) {
-        CacheEntry entry = client.get(serializedKey);
+        EntryHandle entry = client.get(serializedKey);
         if (entry != null) {
             entry.close();
             return true;

--- a/blazingcache-services/src/test/java/blazingcache/services/SimpleServerTest.java
+++ b/blazingcache-services/src/test/java/blazingcache/services/SimpleServerTest.java
@@ -6,7 +6,7 @@
 package blazingcache.services;
 
 import blazingcache.client.CacheClient;
-import blazingcache.client.CacheEntry;
+import blazingcache.client.EntryHandle;
 import blazingcache.network.netty.NettyCacheServerLocator;
 import java.util.Properties;
 import org.junit.Assert;
@@ -25,9 +25,10 @@ public class SimpleServerTest {
                 client.start();
                 assertTrue(client.waitForConnection(10000));
                 client.put("test", "ciao".getBytes(), -1);
-                CacheEntry entry = client.get("test");
-                Assert.assertNotNull(entry);
-                Assert.assertArrayEquals("ciao".getBytes(), entry.getSerializedData());
+                try (EntryHandle entry = client.get("test");) {
+                    Assert.assertNotNull(entry);
+                    Assert.assertArrayEquals("ciao".getBytes(), entry.getSerializedData());
+                }
             }
 
         }


### PR DESCRIPTION
Since new 2.0 API needs an explicit release of entries it is better to break binary compatibility