### PR TITLE
Default to UnpooledByteBufAllocator

### DIFF
--- a/blazingcache-core/src/main/java/blazingcache/client/CacheClient.java
+++ b/blazingcache-core/src/main/java/blazingcache/client/CacheClient.java
@@ -51,6 +51,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -254,6 +255,7 @@ public class CacheClient implements ChannelEventListener, ConnectionRequestInfo,
          * @return the builder itself
          */
         public Builder allocator(ByteBufAllocator allocator) {
+            Objects.requireNonNull(allocator);
             this.allocator = allocator;
             return this;
         }
@@ -265,6 +267,7 @@ public class CacheClient implements ChannelEventListener, ConnectionRequestInfo,
          * @return the builder itself
          */
         public Builder clientId(String clientId) {
+            Objects.requireNonNull(clientId);
             this.clientId = clientId;
             return this;
         }
@@ -290,6 +293,7 @@ public class CacheClient implements ChannelEventListener, ConnectionRequestInfo,
          * @return the builder itself
          */
         public Builder serverLocator(ServerLocator serverLocator) {
+            Objects.requireNonNull(serverLocator);
             this.serverLocator = serverLocator;
             return this;
         }

--- a/blazingcache-core/src/main/java/blazingcache/client/CacheClient.java
+++ b/blazingcache-core/src/main/java/blazingcache/client/CacheClient.java
@@ -305,12 +305,18 @@ public class CacheClient implements ChannelEventListener, ConnectionRequestInfo,
         }
     }
 
+    /**
+     * Start creating a new CacheClient.
+     *
+     * @return a builder for a new client.
+     */
     public static Builder newBuilder() {
         return new Builder();
     }
 
     /**
-     * Create a new CacheClient with the safest default
+     * Create a new CacheClient with the safest default.
+     * Use {@link #newBuilder() } in order to have full control.
      *
      * @param clientId
      * @param sharedSecret
@@ -869,7 +875,6 @@ public class CacheClient implements ChannelEventListener, ConnectionRequestInfo,
     /**
      * Closes the client. It will never try to reconnect again to the server
      *
-     * @throws Exception
      */
     @Override
     public void close() {

--- a/blazingcache-core/src/main/java/blazingcache/client/CacheClient.java
+++ b/blazingcache-core/src/main/java/blazingcache/client/CacheClient.java
@@ -220,6 +220,9 @@ public class CacheClient implements ChannelEventListener, ConnectionRequestInfo,
         }
     }
 
+    /**
+     * Builds a {@link CacheClient}.
+     */
     public final static class Builder {
 
         private Builder() {
@@ -231,32 +234,70 @@ public class CacheClient implements ChannelEventListener, ConnectionRequestInfo,
         private String sharedSecret = "changeit";
         private ServerLocator serverLocator;
 
+        /**
+         * Prefer storing data on direct memory. Defaults to 'true'.
+         *
+         * @param value
+         * @return the builder itself
+         */
         public Builder offHeap(boolean value) {
             this.offHeap = value;
             return this;
         }
 
+        /**
+         * Prefer pooling data according to Netty rules. Defaults to 'false'.
+         *
+         * @param value
+         * @return the builder itself
+         */
         public Builder poolMemoryBuffers(boolean value) {
             this.poolMemoryBuffers = value;
             return this;
         }
 
+        /**
+         * Set the clientId seed. Defaults to 'localhost'.
+         *
+         * @param clientId
+         * @return the builder itself
+         */
         public Builder clientId(String clientId) {
             this.clientId = clientId;
             return this;
         }
 
+        /**
+         * Set the sharedSecret. Defaults to 'changeit'.
+         * This is a legacy configuration parameter, in order
+         * to implement real security please configure JAAS/Kerberos.
+         *
+         * @param sharedSecret
+         * @return the builder itself
+         */
         public Builder sharedSecret(String sharedSecret) {
             this.sharedSecret = sharedSecret;
             return this;
         }
-        
+
+        /**
+         * Set the callback used to discovery cache servers on the network.
+         * There is no default.
+         *
+         * @param serverLocator
+         * @return the builder itself
+         */
         public Builder serverLocator(ServerLocator serverLocator) {
             this.serverLocator = serverLocator;
             return this;
         }
 
-        public CacheClient build() {
+        /**
+         * Builds the client.
+         * @return a new client, to be disposed with {@link CacheClient#close() }
+         * @throws IllegalArgumentException in case of invalid configuration.
+         */
+        public CacheClient build() throws IllegalArgumentException {
             if (serverLocator == null) {
                 throw new IllegalArgumentException("serverLocator must be set");
             }
@@ -270,9 +311,10 @@ public class CacheClient implements ChannelEventListener, ConnectionRequestInfo,
 
     /**
      * Create a new CacheClient with the safest default
+     *
      * @param clientId
      * @param sharedSecret
-     * @param brokerLocator 
+     * @param brokerLocator
      */
     public CacheClient(String clientId, String sharedSecret, ServerLocator brokerLocator) {
         this(clientId, sharedSecret, brokerLocator, true, false /* poolMemoryBuffers = false is safer */);
@@ -335,7 +377,7 @@ public class CacheClient implements ChannelEventListener, ConnectionRequestInfo,
     // visible for testing
     ByteBufAllocator getAllocator() {
         return allocator;
-    }        
+    }
 
     public ServerLocator getBrokerLocator() {
         return brokerLocator;

--- a/blazingcache-core/src/test/java/blazingcache/client/CacheClientBuilderTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/CacheClientBuilderTest.java
@@ -25,8 +25,10 @@ import blazingcache.network.ConnectionRequestInfo;
 import blazingcache.network.ServerLocator;
 import blazingcache.network.ServerNotAvailableException;
 import blazingcache.network.ServerRejectedConnectionException;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.util.internal.PlatformDependent;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
@@ -92,19 +94,13 @@ public class CacheClientBuilderTest {
 
     @Test
     public void testUsePooledByteBuffers() {
+        ByteBufAllocator alloc = new PooledByteBufAllocator(PlatformDependent.directBufferPreferred());
         try (CacheClient client = CacheClient
                 .newBuilder()
                 .serverLocator(serverLocator)
-                .poolMemoryBuffers(true)
+                .allocator(alloc)
                 .build();) {
-            assertTrue(client.getAllocator() instanceof PooledByteBufAllocator);
-        }
-        try (CacheClient client = CacheClient
-                .newBuilder()
-                .serverLocator(serverLocator)
-                .poolMemoryBuffers(false)
-                .build();) {
-            assertTrue(client.getAllocator() instanceof UnpooledByteBufAllocator);
+            assertSame(alloc, client.getAllocator());
         }
     }
 

--- a/blazingcache-core/src/test/java/blazingcache/client/CacheClientBuilderTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/CacheClientBuilderTest.java
@@ -1,0 +1,144 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package blazingcache.client;
+
+import blazingcache.network.Channel;
+import blazingcache.network.ChannelEventListener;
+import blazingcache.network.ConnectionRequestInfo;
+import blazingcache.network.ServerLocator;
+import blazingcache.network.ServerNotAvailableException;
+import blazingcache.network.ServerRejectedConnectionException;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+/**
+ * Tests around cache client builder
+ *
+ * @author enrico.olivelli
+ */
+public class CacheClientBuilderTest {
+
+    private final ServerLocator serverLocator = new ServerLocator() {
+        @Override
+        public Channel connect(ChannelEventListener messageReceiver, ConnectionRequestInfo workerInfo) throws InterruptedException, ServerNotAvailableException, ServerRejectedConnectionException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void brokerDisconnected() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+    };
+
+    @Test
+    public void testDefault() {
+        try (CacheClient client = CacheClient.newBuilder()
+                .serverLocator(serverLocator)
+                .build();) {
+            assertTrue(client.isOffHeap());
+            assertTrue(client.getAllocator() instanceof UnpooledByteBufAllocator);
+            assertTrue(client.getClientId().startsWith("localhost"));
+        }
+    }
+
+    @Test
+    public void testDefaultLegacyConstructor() {
+        try (CacheClient client = new CacheClient("ff", "bar", serverLocator)) {
+            assertTrue(client.isOffHeap());
+            assertTrue(client.getAllocator() instanceof UnpooledByteBufAllocator);
+            assertTrue(client.getClientId().startsWith("ff"));
+        }
+    }
+
+    @Test
+    public void testOffHeap() {
+        try (CacheClient client = CacheClient
+                .newBuilder()
+                .serverLocator(serverLocator)
+                .offHeap(false)
+                .build();) {
+            assertFalse(client.isOffHeap());
+        }
+        try (CacheClient client = CacheClient
+                .newBuilder()
+                .serverLocator(serverLocator)
+                .offHeap(true)
+                .build();) {
+            assertTrue(client.isOffHeap());
+        }
+    }
+
+    @Test
+    public void testUsePooledByteBuffers() {
+        try (CacheClient client = CacheClient
+                .newBuilder()
+                .serverLocator(serverLocator)
+                .poolMemoryBuffers(true)
+                .build();) {
+            assertTrue(client.getAllocator() instanceof PooledByteBufAllocator);
+        }
+        try (CacheClient client = CacheClient
+                .newBuilder()
+                .serverLocator(serverLocator)
+                .poolMemoryBuffers(false)
+                .build();) {
+            assertTrue(client.getAllocator() instanceof UnpooledByteBufAllocator);
+        }
+    }
+
+    @Test
+    public void testClientId() {
+        try (CacheClient client = CacheClient
+                .newBuilder()
+                .serverLocator(serverLocator)
+                .clientId("foo")
+                .build();) {
+            assertTrue(client.getClientId().startsWith("foo"));
+        }
+    }
+
+    @Test
+    public void testSharedSecret() {
+        try (CacheClient client = CacheClient
+                .newBuilder()
+                .serverLocator(serverLocator)
+                .sharedSecret("aaa")
+                .build();) {
+            assertEquals("aaa", client.getSharedSecret());
+        }
+    }
+
+    @Test
+    public void testServerLocator() {
+
+        try (CacheClient client = CacheClient
+                .newBuilder()
+                .serverLocator(serverLocator)
+                .build();) {
+            assertSame(serverLocator, client.getBrokerLocator());
+        }
+    }
+
+}


### PR DESCRIPTION
Changes:
- Default to UnpooledByteBufAllocator
- Introduce a new CacheClient builder

This is the safest default
Netty by default will keep thread local Pools
f the application uses many different threads while accessing the cache (like a WebApplication)
but it does not perform frequent operations (for us those operations will lead to ByteBuffer allocations)
pooling ByteBuffers will lead to a large usage of direct memory
which won't be reclaimed, because by default Netty reclaims memory
per thread and every N allocations

Many thanks to @normanmaurer who helped understanding the troubles that may be caused by using PooledByteBufAllocator under certain conditions.

