### PR TITLE
Add SO_REUSEADDR option to channel

### DIFF
--- a/blazingcache-core/src/main/java/blazingcache/network/netty/NettyChannelAcceptor.java
+++ b/blazingcache-core/src/main/java/blazingcache/network/netty/NettyChannelAcceptor.java
@@ -222,13 +222,13 @@ public class NettyChannelAcceptor implements AutoCloseable {
 
                     ch.pipeline().addLast("lengthprepender", new LengthFieldPrepender(4));
                     ch.pipeline().addLast("lengthbaseddecoder", new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4));
-//
                     ch.pipeline().addLast("messageencoder", new DataMessageEncoder());
                     ch.pipeline().addLast("messagedecoder", new DataMessageDecoder());
                     ch.pipeline().addLast(new InboundMessageHandler(session));
                 }
             })
             .option(ChannelOption.SO_BACKLOG, 128)
+            .option(ChannelOption.SO_REUSEADDR, true)
             .childOption(ChannelOption.SO_KEEPALIVE, true);
 
         ChannelFuture f = b.bind(host, port).sync(); // (7)


### PR DESCRIPTION
Just add SO_REUSEADDR option to NettyChannelAcceptor

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
