### PR TITLE
Update junit

### DIFF
--- a/blazingcache-jcache/pom.xml
+++ b/blazingcache-jcache/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>                        
+            <version>4.13.2</version>                        
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/blazingcache-services/pom.xml
+++ b/blazingcache-services/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <libs.netty4>4.1.68.Final</libs.netty4>
+        <libs.netty4>4.1.72.Final</libs.netty4>
         <libs.netty4.tcnative>2.0.46.Final</libs.netty4.tcnative>
         <libs.servletapi>3.1.0</libs.servletapi>
         <libs.junit>4.13.2</libs.junit>

--- a/pom.xml
+++ b/pom.xml
@@ -65,12 +65,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <libs.netty4>4.1.50.Final</libs.netty4>
-        <libs.netty4.tcnative>2.0.31.Final</libs.netty4.tcnative>
+        <libs.netty4>4.1.68.Final</libs.netty4>
+        <libs.netty4.tcnative>2.0.46.Final</libs.netty4.tcnative>
         <libs.servletapi>3.1.0</libs.servletapi>
-        <libs.junit>4.12</libs.junit>
+        <libs.junit>4.13.2</libs.junit>
         <libs.jackson.mapper>1.9.13</libs.jackson.mapper>
-        <libs.zookeeper>3.6.1</libs.zookeeper>
+        <libs.zookeeper>3.6.3</libs.zookeeper>
         <libs.snappy>1.1.7.6</libs.snappy>
         <libs.metrics>4.1.9</libs.metrics>
         <libs.commonsio>2.7</libs.commonsio>


### PR DESCRIPTION
Update junit due to CVEs (forgot to do so under blazingcache-jcache and blazingcache-services)

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
