### PR TITLE
#174 Speed up messageId generation

### DIFF
--- a/blazingcache-core/src/main/java/blazingcache/network/jvm/JVMChannel.java
+++ b/blazingcache-core/src/main/java/blazingcache/network/jvm/JVMChannel.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -44,6 +45,7 @@ import java.util.logging.Logger;
 public class JVMChannel extends Channel {
 
     private static final Logger LOGGER = Logger.getLogger(JVMChannel.class.getName());
+    private static final AtomicLong idGenerator = new AtomicLong();
     private volatile boolean active = false;
     private final Map<String, ReplyCallback> pendingReplyMessages = new ConcurrentHashMap<>();
     private final Map<String, Message> pendingReplyMessagesSource = new ConcurrentHashMap<>();
@@ -89,7 +91,7 @@ public class JVMChannel extends Channel {
 
     @Override
     public void sendOneWayMessage(Message message, SendResultCallback callback) {
-        message.setMessageId(UUID.randomUUID().toString());
+        message.setMessageId(idGenerator.incrementAndGet() + "");
         Message _message = cloneMessage(message);
 //        System.out.println("[JVM] sendOneWayMessage " + message);
         if (!active || executionserializer.isShutdown()) {
@@ -121,7 +123,7 @@ public class JVMChannel extends Channel {
 
     @Override
     public void sendReplyMessage(Message inAnswerTo, Message message) {
-        message.setMessageId(UUID.randomUUID().toString());
+        message.setMessageId(idGenerator.incrementAndGet() + "");
         Message _message = cloneMessage(message);
         if (executionserializer.isShutdown()) {
             LOGGER.log(Level.SEVERE,"channel shutdown, discarding reply message " + _message);
@@ -147,7 +149,7 @@ public class JVMChannel extends Channel {
 
     @Override
     public void sendMessageWithAsyncReply(Message message, long timeout, ReplyCallback callback) {
-        message.setMessageId(UUID.randomUUID().toString());
+        message.setMessageId(idGenerator.incrementAndGet() + "");
         Message _message = cloneMessage(message);
         if (executionserializer.isShutdown()) {
             LOGGER.log(Level.SEVERE,"[JVM] channel shutdown, discarding sendMessageWithAsyncReply");

--- a/blazingcache-core/src/main/java/blazingcache/network/jvm/JVMChannel.java
+++ b/blazingcache-core/src/main/java/blazingcache/network/jvm/JVMChannel.java
@@ -45,7 +45,7 @@ import java.util.logging.Logger;
 public class JVMChannel extends Channel {
 
     private static final Logger LOGGER = Logger.getLogger(JVMChannel.class.getName());
-    private static final AtomicLong idGenerator = new AtomicLong();
+    private static final AtomicLong ID_GENERATOR = new AtomicLong();
     private volatile boolean active = false;
     private final Map<String, ReplyCallback> pendingReplyMessages = new ConcurrentHashMap<>();
     private final Map<String, Message> pendingReplyMessagesSource = new ConcurrentHashMap<>();
@@ -91,7 +91,7 @@ public class JVMChannel extends Channel {
 
     @Override
     public void sendOneWayMessage(Message message, SendResultCallback callback) {
-        message.setMessageId(idGenerator.incrementAndGet() + "");
+        message.setMessageId(ID_GENERATOR.incrementAndGet() + "");
         Message _message = cloneMessage(message);
 //        System.out.println("[JVM] sendOneWayMessage " + message);
         if (!active || executionserializer.isShutdown()) {
@@ -123,7 +123,7 @@ public class JVMChannel extends Channel {
 
     @Override
     public void sendReplyMessage(Message inAnswerTo, Message message) {
-        message.setMessageId(idGenerator.incrementAndGet() + "");
+        message.setMessageId(ID_GENERATOR.incrementAndGet() + "");
         Message _message = cloneMessage(message);
         if (executionserializer.isShutdown()) {
             LOGGER.log(Level.SEVERE,"channel shutdown, discarding reply message " + _message);
@@ -149,7 +149,7 @@ public class JVMChannel extends Channel {
 
     @Override
     public void sendMessageWithAsyncReply(Message message, long timeout, ReplyCallback callback) {
-        message.setMessageId(idGenerator.incrementAndGet() + "");
+        message.setMessageId(ID_GENERATOR.incrementAndGet() + "");
         Message _message = cloneMessage(message);
         if (executionserializer.isShutdown()) {
             LOGGER.log(Level.SEVERE,"[JVM] channel shutdown, discarding sendMessageWithAsyncReply");

--- a/blazingcache-core/src/main/java/blazingcache/network/jvm/JVMChannel.java
+++ b/blazingcache-core/src/main/java/blazingcache/network/jvm/JVMChannel.java
@@ -28,7 +28,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -45,9 +44,10 @@ import java.util.logging.Logger;
 public class JVMChannel extends Channel {
 
     private static final Logger LOGGER = Logger.getLogger(JVMChannel.class.getName());
-    private static final AtomicLong ID_GENERATOR = new AtomicLong();
     private static final AtomicLong CHANNEL_ID_GENERATOR = new AtomicLong();
+
     private volatile boolean active = false;
+    private final AtomicLong messageIdGenerator = new AtomicLong();
     private final Map<String, ReplyCallback> pendingReplyMessages = new ConcurrentHashMap<>();
     private final Map<String, Message> pendingReplyMessagesSource = new ConcurrentHashMap<>();
     private JVMChannel otherSide;
@@ -92,7 +92,7 @@ public class JVMChannel extends Channel {
 
     @Override
     public void sendOneWayMessage(Message message, SendResultCallback callback) {
-        message.setMessageId(ID_GENERATOR.incrementAndGet() + "");
+        message.setMessageId(messageIdGenerator.incrementAndGet() + "");
         Message _message = cloneMessage(message);
 //        System.out.println("[JVM] sendOneWayMessage " + message);
         if (!active || executionserializer.isShutdown()) {
@@ -124,7 +124,7 @@ public class JVMChannel extends Channel {
 
     @Override
     public void sendReplyMessage(Message inAnswerTo, Message message) {
-        message.setMessageId(ID_GENERATOR.incrementAndGet() + "");
+        message.setMessageId(messageIdGenerator.incrementAndGet() + "");
         Message _message = cloneMessage(message);
         if (executionserializer.isShutdown()) {
             LOGGER.log(Level.SEVERE,"channel shutdown, discarding reply message " + _message);
@@ -150,7 +150,7 @@ public class JVMChannel extends Channel {
 
     @Override
     public void sendMessageWithAsyncReply(Message message, long timeout, ReplyCallback callback) {
-        message.setMessageId(ID_GENERATOR.incrementAndGet() + "");
+        message.setMessageId(messageIdGenerator.incrementAndGet() + "");
         Message _message = cloneMessage(message);
         if (executionserializer.isShutdown()) {
             LOGGER.log(Level.SEVERE,"[JVM] channel shutdown, discarding sendMessageWithAsyncReply");

--- a/blazingcache-core/src/main/java/blazingcache/network/jvm/JVMChannel.java
+++ b/blazingcache-core/src/main/java/blazingcache/network/jvm/JVMChannel.java
@@ -53,7 +53,7 @@ public class JVMChannel extends Channel {
     private JVMChannel otherSide;
     private final ExecutorService callbackexecutor = Executors.newCachedThreadPool();
     private final ExecutorService executionserializer = Executors.newFixedThreadPool(1);
-    private String id = CHANNEL_ID_GENERATOR.incrementAndGet() + "";
+    private long id = CHANNEL_ID_GENERATOR.incrementAndGet();
 
     @Override
     public String toString() {

--- a/blazingcache-core/src/main/java/blazingcache/network/jvm/JVMChannel.java
+++ b/blazingcache-core/src/main/java/blazingcache/network/jvm/JVMChannel.java
@@ -46,13 +46,14 @@ public class JVMChannel extends Channel {
 
     private static final Logger LOGGER = Logger.getLogger(JVMChannel.class.getName());
     private static final AtomicLong ID_GENERATOR = new AtomicLong();
+    private static final AtomicLong CHANNEL_ID_GENERATOR = new AtomicLong();
     private volatile boolean active = false;
     private final Map<String, ReplyCallback> pendingReplyMessages = new ConcurrentHashMap<>();
     private final Map<String, Message> pendingReplyMessagesSource = new ConcurrentHashMap<>();
     private JVMChannel otherSide;
     private final ExecutorService callbackexecutor = Executors.newCachedThreadPool();
     private final ExecutorService executionserializer = Executors.newFixedThreadPool(1);
-    private String id = UUID.randomUUID().toString();
+    private String id = CHANNEL_ID_GENERATOR.incrementAndGet() + "";
 
     @Override
     public String toString() {

--- a/blazingcache-core/src/main/java/blazingcache/network/netty/NettyChannel.java
+++ b/blazingcache-core/src/main/java/blazingcache/network/netty/NettyChannel.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
@@ -48,9 +47,9 @@ public class NettyChannel extends Channel {
     private static final boolean DISCONNECT_ON_PENDING_REPLY_TIMEOUT = Boolean.parseBoolean(System.getProperty("blazingcache.nettychannel.disconnectonpendingreplytimeout", "true"));
     private volatile SocketChannel socket;
     private static final Logger LOGGER = Logger.getLogger(NettyChannel.class.getName());
-    private static final AtomicLong ID_GENERATOR = new AtomicLong();
     private static final AtomicLong CHANNEL_ID_GENERATOR = new AtomicLong();
 
+    private final AtomicLong messageIdGenerator = new AtomicLong();
     private final Map<String, ReplyCallback> pendingReplyMessages = new ConcurrentHashMap<>();
     private final Map<String, Message> pendingReplyMessagesSource = new ConcurrentHashMap<>();
     private final Map<String, Long> pendingReplyMessagesDeadline = new ConcurrentHashMap<>();
@@ -103,7 +102,7 @@ public class NettyChannel extends Channel {
     @Override
     public void sendOneWayMessage(Message message, SendResultCallback callback) {
         if (message.getMessageId() == null) {
-            message.setMessageId(ID_GENERATOR.incrementAndGet() + "");
+            message.setMessageId(messageIdGenerator.incrementAndGet() + "");
         }
         SocketChannel _socket = this.socket;
         if (_socket == null || !_socket.isOpen()) {
@@ -129,7 +128,7 @@ public class NettyChannel extends Channel {
     @Override
     public void sendReplyMessage(Message inAnswerTo, Message message) {
         if (message.getMessageId() == null) {
-            message.setMessageId(ID_GENERATOR.incrementAndGet() + "");
+            message.setMessageId(messageIdGenerator.incrementAndGet() + "");
         }
         if (this.socket == null) {
             LOGGER.log(Level.SEVERE, this + " channel not active, discarding reply message " + message);
@@ -182,7 +181,7 @@ public class NettyChannel extends Channel {
     @Override
     public void sendMessageWithAsyncReply(Message message, long timeout, ReplyCallback callback) {
         if (message.getMessageId() == null) {
-            message.setMessageId(ID_GENERATOR.incrementAndGet() + "");
+            message.setMessageId(messageIdGenerator.incrementAndGet() + "");
         }
         if (!isValid()) {
             submitCallback(() -> {

--- a/blazingcache-core/src/main/java/blazingcache/network/netty/NettyChannel.java
+++ b/blazingcache-core/src/main/java/blazingcache/network/netty/NettyChannel.java
@@ -56,7 +56,7 @@ public class NettyChannel extends Channel {
     private final ExecutorService callbackexecutor;
     private final NettyConnector connector;
     private volatile boolean ioErrors = false;
-    private final long id = idGenerator.incrementAndGet();
+    private final String id = UUID.randomUUID().toString();
     private final boolean disconnectOnReplyTimeout;
 
     @Override
@@ -102,7 +102,7 @@ public class NettyChannel extends Channel {
     @Override
     public void sendOneWayMessage(Message message, SendResultCallback callback) {
         if (message.getMessageId() == null) {
-            message.setMessageId(UUID.randomUUID().toString());
+            message.setMessageId(idGenerator.incrementAndGet() + "");
         }
         SocketChannel _socket = this.socket;
         if (_socket == null || !_socket.isOpen()) {
@@ -128,7 +128,7 @@ public class NettyChannel extends Channel {
     @Override
     public void sendReplyMessage(Message inAnswerTo, Message message) {
         if (message.getMessageId() == null) {
-            message.setMessageId(UUID.randomUUID().toString());
+            message.setMessageId(idGenerator.incrementAndGet() + "");
         }
         if (this.socket == null) {
             LOGGER.log(Level.SEVERE, this + " channel not active, discarding reply message " + message);
@@ -181,7 +181,7 @@ public class NettyChannel extends Channel {
     @Override
     public void sendMessageWithAsyncReply(Message message, long timeout, ReplyCallback callback) {
         if (message.getMessageId() == null) {
-            message.setMessageId(UUID.randomUUID().toString());
+            message.setMessageId(idGenerator.incrementAndGet() + "");
         }
         if (!isValid()) {
             submitCallback(() -> {

--- a/blazingcache-core/src/main/java/blazingcache/network/netty/NettyChannel.java
+++ b/blazingcache-core/src/main/java/blazingcache/network/netty/NettyChannel.java
@@ -49,6 +49,7 @@ public class NettyChannel extends Channel {
     private volatile SocketChannel socket;
     private static final Logger LOGGER = Logger.getLogger(NettyChannel.class.getName());
     private static final AtomicLong ID_GENERATOR = new AtomicLong();
+    private static final AtomicLong CHANNEL_ID_GENERATOR = new AtomicLong();
 
     private final Map<String, ReplyCallback> pendingReplyMessages = new ConcurrentHashMap<>();
     private final Map<String, Message> pendingReplyMessagesSource = new ConcurrentHashMap<>();
@@ -56,7 +57,7 @@ public class NettyChannel extends Channel {
     private final ExecutorService callbackexecutor;
     private final NettyConnector connector;
     private volatile boolean ioErrors = false;
-    private final String id = UUID.randomUUID().toString();
+    private final String id = CHANNEL_ID_GENERATOR.incrementAndGet() + "";
     private final boolean disconnectOnReplyTimeout;
 
     @Override

--- a/blazingcache-core/src/main/java/blazingcache/network/netty/NettyChannel.java
+++ b/blazingcache-core/src/main/java/blazingcache/network/netty/NettyChannel.java
@@ -48,7 +48,7 @@ public class NettyChannel extends Channel {
     private static final boolean DISCONNECT_ON_PENDING_REPLY_TIMEOUT = Boolean.parseBoolean(System.getProperty("blazingcache.nettychannel.disconnectonpendingreplytimeout", "true"));
     private volatile SocketChannel socket;
     private static final Logger LOGGER = Logger.getLogger(NettyChannel.class.getName());
-    private static final AtomicLong idGenerator = new AtomicLong();
+    private static final AtomicLong ID_GENERATOR = new AtomicLong();
 
     private final Map<String, ReplyCallback> pendingReplyMessages = new ConcurrentHashMap<>();
     private final Map<String, Message> pendingReplyMessagesSource = new ConcurrentHashMap<>();
@@ -102,7 +102,7 @@ public class NettyChannel extends Channel {
     @Override
     public void sendOneWayMessage(Message message, SendResultCallback callback) {
         if (message.getMessageId() == null) {
-            message.setMessageId(idGenerator.incrementAndGet() + "");
+            message.setMessageId(ID_GENERATOR.incrementAndGet() + "");
         }
         SocketChannel _socket = this.socket;
         if (_socket == null || !_socket.isOpen()) {
@@ -128,7 +128,7 @@ public class NettyChannel extends Channel {
     @Override
     public void sendReplyMessage(Message inAnswerTo, Message message) {
         if (message.getMessageId() == null) {
-            message.setMessageId(idGenerator.incrementAndGet() + "");
+            message.setMessageId(ID_GENERATOR.incrementAndGet() + "");
         }
         if (this.socket == null) {
             LOGGER.log(Level.SEVERE, this + " channel not active, discarding reply message " + message);
@@ -181,7 +181,7 @@ public class NettyChannel extends Channel {
     @Override
     public void sendMessageWithAsyncReply(Message message, long timeout, ReplyCallback callback) {
         if (message.getMessageId() == null) {
-            message.setMessageId(idGenerator.incrementAndGet() + "");
+            message.setMessageId(ID_GENERATOR.incrementAndGet() + "");
         }
         if (!isValid()) {
             submitCallback(() -> {

--- a/blazingcache-core/src/main/java/blazingcache/network/netty/NettyChannel.java
+++ b/blazingcache-core/src/main/java/blazingcache/network/netty/NettyChannel.java
@@ -57,7 +57,7 @@ public class NettyChannel extends Channel {
     private final ExecutorService callbackexecutor;
     private final NettyConnector connector;
     private volatile boolean ioErrors = false;
-    private final String id = CHANNEL_ID_GENERATOR.incrementAndGet() + "";
+    private final long id = CHANNEL_ID_GENERATOR.incrementAndGet();
     private final boolean disconnectOnReplyTimeout;
 
     @Override


### PR DESCRIPTION
Change messages and replies id from uuid to long to speedup the id generation.
The ID is only stored by the sender of the first request, receivers of the message use the messageID to set the replyMessageID, so a simple AtomicLong per host should suffice.

I kept the (reply)messageID as String to avoid changing a lot of places

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
