### PR TITLE
Fix load requests to send load type messages. Closes #182

### DIFF
--- a/blazingcache-core/src/main/java/blazingcache/network/Message.java
+++ b/blazingcache-core/src/main/java/blazingcache/network/Message.java
@@ -63,7 +63,7 @@ public final class Message {
         data.put("key", key);
         data.put("data", serializedData);
         data.put("expiretime", expiretime);
-        return new Message(clientId, TYPE_PUT_ENTRY, data);
+        return new Message(clientId, TYPE_LOAD_ENTRY, data);
     }
 
     public static Message UNREGISTER_ENTRY(String clientId, List<RawString> keys) {

--- a/blazingcache-core/src/main/java/blazingcache/server/CacheServer.java
+++ b/blazingcache-core/src/main/java/blazingcache/server/CacheServer.java
@@ -336,7 +336,7 @@ public class CacheServer implements AutoCloseable {
             if (sourceClientId != null) {
                 clientsForKey.remove(sourceClientId);
             }
-            LOGGER.log(Level.FINEST, "putEntry from {0}, key={1}, clientsForKey:{2}", new Object[]{sourceClientId, key, clientsForKey});
+            LOGGER.log(Level.FINEST, "loadEntry from {0}, key={1}, clientsForKey:{2}", new Object[]{sourceClientId, key, clientsForKey});
             cacheStatus.registerKeyForClient(key, sourceClientId, expiretime);
             locksManager.releaseWriteLockForKey(key, sourceClientId, lockID);
             onFinish.onResult(key, null);

--- a/blazingcache-core/src/test/java/blazingcache/client/LoadAndPutEntryTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/LoadAndPutEntryTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to Diennea S.r.l. under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Diennea S.r.l. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package blazingcache.client;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import blazingcache.network.ServerHostData;
+import blazingcache.network.netty.NettyCacheServerLocator;
+import blazingcache.server.CacheServer;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+
+/**
+ * Test for load and put entry interactions
+ * 
+ * @author diego.salvi
+ */
+public class LoadAndPutEntryTest {
+
+    @Test
+    public void basicTest() throws Exception {
+        byte[] data1 = "testdata1".getBytes(StandardCharsets.UTF_8);
+        byte[] data2 = "testdata2".getBytes(StandardCharsets.UTF_8);
+
+        ServerHostData serverHostData = new ServerHostData("localhost", 1234, "test", false, null);
+        try (CacheServer cacheServer = new CacheServer("ciao", serverHostData)) {
+            cacheServer.setClientFetchTimeout(1000);
+            cacheServer.start();
+            try (CacheClient client1 =
+                    new CacheClient("theClient1", "ciao", new NettyCacheServerLocator(serverHostData));
+                    CacheClient client2 = new CacheClient("theClient2", "ciao", new NettyCacheServerLocator(
+                            serverHostData));
+                    CacheClient client3 = new CacheClient("theClient3", "ciao", new NettyCacheServerLocator(
+                            serverHostData));) {
+
+                client1.start();
+                client2.start();
+                client3.start();
+
+                assertTrue(client1.waitForConnection(10000));
+                assertTrue(client2.waitForConnection(10000));
+                assertTrue(client3.waitForConnection(10000));
+
+                assertNull(client1.get("foo"));
+                assertNull(client2.get("foo"));
+                assertNull(client3.get("foo"));
+
+                // foo with data1 only on 1
+                client1.load("foo", data1, 0);
+                EntryHandle handle;
+
+                // fetch foo with data1 on 2
+                handle = client2.fetch("foo");
+                assertNotNull(handle);
+                assertArrayEquals(data1, handle.getSerializedData());
+
+                // overwrite globally foo with data2 on 1
+                client1.put("foo", data2, 0);
+
+                // read local foo with data2
+                handle = client1.fetch("foo");
+                assertNotNull(handle);
+                assertArrayEquals(data2, handle.getSerializedData());
+
+                // read local foo with data2
+                handle = client2.fetch("foo");
+                assertNotNull(handle);
+                assertArrayEquals(data2, handle.getSerializedData());
+
+                // fetch remotely foo with data2
+                handle = client3.fetch("foo");
+                assertNotNull(handle);
+                assertArrayEquals(data2, handle.getSerializedData());
+
+                // overwrite locally foo with data1 on 1
+                client1.load("foo", data1, 0);
+
+                // read local foo with data1
+                handle = client1.fetch("foo");
+                assertNotNull(handle);
+                assertArrayEquals(data1, handle.getSerializedData());
+
+                // read local foo with data2
+                handle = client2.fetch("foo");
+                assertNotNull(handle);
+                assertArrayEquals(data2, handle.getSerializedData());
+
+                // read local foo with data2
+                handle = client3.fetch("foo");
+                assertNotNull(handle);
+                assertArrayEquals(data2, handle.getSerializedData());
+
+                // overwrite globally foo with data2 on 3
+                // foo on 1 must change too
+                client3.put("foo", data2, 0);
+
+                // read pushed local foo with data2
+                handle = client1.fetch("foo");
+                assertNotNull(handle);
+                assertArrayEquals(data2, handle.getSerializedData());
+
+                // read pushed local foo with data2
+                handle = client2.fetch("foo");
+                assertNotNull(handle);
+                assertArrayEquals(data2, handle.getSerializedData());
+
+                // read pushed local foo with data2
+                handle = client3.fetch("foo");
+                assertNotNull(handle);
+                assertArrayEquals(data2, handle.getSerializedData());
+
+            }
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
Change Message to the right type when generating LOAD messages instead of sending PUT messages (and changing expected cache behaviour)

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
