### PR TITLE
Distribute fetch requests between clients with same priority

### DIFF
--- a/blazingcache-core/src/main/java/blazingcache/server/CacheServer.java
+++ b/blazingcache-core/src/main/java/blazingcache/server/CacheServer.java
@@ -31,6 +31,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -453,7 +454,11 @@ public class CacheServer implements AutoCloseable {
                 }
             }
             candidates.sort((a, b) -> {
-                return b.getFetchPriority() - a.getFetchPriority();
+                int priorityComparison = b.getFetchPriority() - a.getFetchPriority();
+                if (priorityComparison == 0) {
+                    return ThreadLocalRandom.current().nextInt();
+                }
+                return priorityComparison;
             });
 
             boolean foundOneGoodClientConnected = false;


### PR DESCRIPTION
Currently, if there are multiple clients with the same priority, the same client is always chosen to serve the fetch.

With this implementation the client is chosen randomly. All clients with the same priority should be able to service a fetch for the same key at least once.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
