### PR TITLE
upgraded to target 17

### DIFF
--- a/.github/workflows/pr-validation-test.yml
+++ b/.github/workflows/pr-validation-test.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
-      - name: 'Set up JDK 11'
+      - name: 'Set up JDK 17'
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '17'
       - name: 'Cache Maven packages'
         uses: actions/cache@v2
         with:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
-      - name: 'Set up JDK 11'
+      - name: 'Set up JDK 17'
         uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: '17'
       - name: 'Cache Maven packages'
         uses: actions/cache@v2
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 jobs:
   include:
   - stage: test
-    jdk: openjdk11
+    jdk: openjdk17
     script: mvn verify -Dmaven.test.redirectTestOutputToFile=true jacoco:report coveralls:report
 
 branches:

--- a/blazingcache-core/pom.xml
+++ b/blazingcache-core/pom.xml
@@ -18,8 +18,8 @@
     </licenses>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
     <build>
         <plugins>
@@ -137,6 +137,11 @@
             <artifactId>slf4j-jdk14</artifactId>
             <version>${libs.slf4j}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>${libs.bouncycastle}</version>
         </dependency>
     </dependencies>
 </project>

--- a/blazingcache-jcache/pom.xml
+++ b/blazingcache-jcache/pom.xml
@@ -19,8 +19,8 @@
     </licenses>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>

--- a/blazingcache-services/pom.xml
+++ b/blazingcache-services/pom.xml
@@ -18,8 +18,8 @@
     </licenses>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@
     </issueManagement>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <libs.netty4>4.1.72.Final</libs.netty4>
         <libs.netty4.tcnative>2.0.46.Final</libs.netty4.tcnative>
         <libs.servletapi>4.0.1</libs.servletapi>
@@ -81,6 +81,7 @@
         <libs.spotbugsmaven>4.7.2.0</libs.spotbugsmaven>
         <libs.jacoco>0.8.8</libs.jacoco>
         <libs.slf4j>2.0.3</libs.slf4j>
+        <libs.bouncycastle>1.70</libs.bouncycastle>
     </properties>
     <dependencies>
         <dependency>
@@ -223,10 +224,10 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.10.1</version>
+                        <version>3.11.0</version>
                         <configuration>
                             <encoding>${project.build.sourceEncoding}</encoding>
-                            <release>8</release>
+                            <release>17</release>
                         </configuration>
                     </plugin>
                     <plugin>
@@ -282,10 +283,10 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.10.1</version>
+                        <version>3.11.0</version>
                         <configuration>
                             <encoding>${project.build.sourceEncoding}</encoding>
-                            <release>8</release>
+                            <release>17</release>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
upgraded target and source version to java 17.
java 15 dropped package `sun.security.x509` so dependency to `bouncycastle` is now required

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
