### PR TITLE
revert to target 8

### DIFF
--- a/.github/workflows/pr-validation-test.yml
+++ b/.github/workflows/pr-validation-test.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
-      - name: 'Set up JDK 17'
+      - name: 'Set up JDK 11'
         uses: actions/setup-java@v1
         with:
-          java-version: '17'
+          java-version: '11'
       - name: 'Cache Maven packages'
         uses: actions/cache@v2
         with:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
-      - name: 'Set up JDK 17'
+      - name: 'Set up JDK 11'
         uses: actions/setup-java@v1
         with:
-          java-version: '17'
+          java-version: '11'
       - name: 'Cache Maven packages'
         uses: actions/cache@v2
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 jobs:
   include:
   - stage: test
-    jdk: openjdk17
+    jdk: openjdk11
     script: mvn verify -Dmaven.test.redirectTestOutputToFile=true jacoco:report coveralls:report
 
 branches:

--- a/blazingcache-core/pom.xml
+++ b/blazingcache-core/pom.xml
@@ -142,6 +142,7 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
             <version>${libs.bouncycastle}</version>
+            <scope>provided</scope>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/blazingcache-core/pom.xml
+++ b/blazingcache-core/pom.xml
@@ -18,8 +18,8 @@
     </licenses>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
     <build>
         <plugins>
@@ -142,6 +142,7 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
             <version>${libs.bouncycastle}</version>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 </project>

--- a/blazingcache-jcache/pom.xml
+++ b/blazingcache-jcache/pom.xml
@@ -19,8 +19,8 @@
     </licenses>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>

--- a/blazingcache-services/pom.xml
+++ b/blazingcache-services/pom.xml
@@ -18,8 +18,8 @@
     </licenses>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@
     </issueManagement>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <libs.netty4>4.1.94.Final</libs.netty4>
         <libs.netty4.tcnative>2.0.62.Final</libs.netty4.tcnative>
         <libs.servletapi>4.0.1</libs.servletapi>
@@ -238,10 +238,10 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.11.0</version>
+                        <version>3.10.1</version>
                         <configuration>
                             <encoding>${project.build.sourceEncoding}</encoding>
-                            <release>17</release>
+<!--                            <release>8</release>-->
                         </configuration>
                     </plugin>
                     <plugin>
@@ -297,10 +297,10 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.11.0</version>
+                        <version>3.10.1</version>
                         <configuration>
                             <encoding>${project.build.sourceEncoding}</encoding>
-                            <release>17</release>
+                            <release>8</release>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
                         <version>3.10.1</version>
                         <configuration>
                             <encoding>${project.build.sourceEncoding}</encoding>
-<!--                            <release>8</release>-->
+                            <release>8</release>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
This is a revert PR for #194 

- Reverted source and target version to 8
- kept the dependecy for `org.bouncycastle:bcpkix-jdk15on:1.70` (as optional) because it's needed from jre15+

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
