### PR TITLE
Add Release CI action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on: 
+  push: 
+    tags: 
+      - '*'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: mvn -B package -DskipTests
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: "blazingcache-services/target/*zip"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          generateReleaseNotes: true


### PR DESCRIPTION
Summary:
- when we cut a release, automatically attach the ZIP file to the release page