### PR TITLE
Java EE to Jakarta EE migration.

### DIFF
--- a/blazingcache-core/pom.xml
+++ b/blazingcache-core/pom.xml
@@ -45,8 +45,8 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <version>${libs.servletapi}</version>
             <scope>provided</scope>
         </dependency>

--- a/blazingcache-core/src/main/java/blazingcache/server/HttpAPIImplementation.java
+++ b/blazingcache-core/src/main/java/blazingcache/server/HttpAPIImplementation.java
@@ -29,9 +29,9 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**

--- a/blazingcache-core/src/main/java/blazingcache/server/embedded/EmbeddedServerAPIServlet.java
+++ b/blazingcache-core/src/main/java/blazingcache/server/embedded/EmbeddedServerAPIServlet.java
@@ -20,10 +20,10 @@
 package blazingcache.server.embedded;
 
 import java.io.IOException;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Servlet API Client

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <libs.netty4>4.1.94.Final</libs.netty4>
         <libs.netty4.tcnative>2.0.62.Final</libs.netty4.tcnative>
-        <libs.servletapi>4.0.1</libs.servletapi>
+        <libs.servletapi>6.0.0</libs.servletapi>
         <libs.junit>4.13.2</libs.junit>
         <libs.jackson.databind>2.15.2</libs.jackson.databind>
         <libs.zookeeper>3.8.2</libs.zookeeper>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <libs.jcip-annotations>1.0</libs.jcip-annotations>
         <libs.spotbugsmaven.annotations>4.7.2</libs.spotbugsmaven.annotations>
         <libs.spotbugsmaven>4.7.2.0</libs.spotbugsmaven>
-        <libs.jacoco>0.8.8</libs.jacoco>
+        <libs.jacoco>0.8.14</libs.jacoco>
         <libs.slf4j>2.0.3</libs.slf4j>
         <libs.bouncycastle>1.70</libs.bouncycastle>
     </properties>


### PR DESCRIPTION
Migrated `javax.servlet:javax.servlet-api:4.0.1` to `jakarta.servlet:jakarta.servlet-api:6.0.0`.

- [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
