### PR TITLE
Fix #188: avoid per-key stalls on concurrent fetch and invalidate (Fix #180 flaky too)

### DIFF
--- a/blazingcache-core/src/main/java/blazingcache/server/CacheServer.java
+++ b/blazingcache-core/src/main/java/blazingcache/server/CacheServer.java
@@ -469,18 +469,36 @@ public class CacheServer implements AutoCloseable {
     public void lockKey(RawString key, String sourceClientId, SimpleCallback<String> onFinish) {
         Runnable action = () -> {
             final LockID lockID = locksManager.acquireWriteLockForKey(key, sourceClientId);
-            cacheStatus.clientLockedKey(sourceClientId, key, lockID);
-            onFinish.onResult(lockID.stamp + "", null);
+            try {
+                cacheStatus.clientLockedKey(sourceClientId, key, lockID);
+                onFinish.onResult(lockID.stamp + "", null);
+            } catch (Throwable t) {
+                // release the just-acquired lock so the key is not write-locked forever
+                LOGGER.log(Level.SEVERE, "error in lockKey for key " + key + ", releasing the lock", t);
+                try {
+                    cacheStatus.clientUnlockedKey(sourceClientId, key, lockID);
+                    locksManager.releaseWriteLockForKey(key, sourceClientId, lockID);
+                } catch (Throwable release) {
+                    LOGGER.log(Level.SEVERE, "error releasing lock after failed lockKey for key " + key, release);
+                }
+                onFinish.onResult(null, t);
+            }
         };
         executeOnHandler("lockKey " + sourceClientId + "," + key, action);
     }
 
     public void unlockKey(RawString key, String sourceClientId, String lockId, SimpleCallback<String> onFinish) {
         Runnable action = () -> {
-            LockID lockID = new LockID(Long.parseLong(lockId));
-            locksManager.releaseWriteLockForKey(key, lockId, lockID);
-            cacheStatus.clientUnlockedKey(sourceClientId, key, lockID);
-            onFinish.onResult(lockID.stamp + "", null);
+            try {
+                LockID lockID = new LockID(Long.parseLong(lockId));
+                locksManager.releaseWriteLockForKey(key, lockId, lockID);
+                cacheStatus.clientUnlockedKey(sourceClientId, key, lockID);
+                onFinish.onResult(lockID.stamp + "", null);
+            } catch (Throwable t) {
+                // a malformed lockId or a stale/wrong stamp must not leave the caller hanging
+                LOGGER.log(Level.SEVERE, "error in unlockKey for key " + key + " lockId " + lockId, t);
+                onFinish.onResult(null, t);
+            }
         };
         executeOnHandler("unlockKey " + sourceClientId + "," + key, action);
     }

--- a/blazingcache-core/src/main/java/blazingcache/server/CacheServer.java
+++ b/blazingcache-core/src/main/java/blazingcache/server/CacheServer.java
@@ -40,6 +40,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
@@ -296,32 +297,44 @@ public class CacheServer implements AutoCloseable {
                 onFinish.onResult(null, new Exception("invalid clientProvidedLockId " + clientProvidedLockId));
                 return;
             }
-            Set<String> clientsForKey = cacheStatus.getClientsForKey(key);
-            if (sourceClientId != null) {
-                clientsForKey.remove(sourceClientId);
-            }
-            LOGGER.log(Level.FINEST, "putEntry from {0}, key={1}, clientsForKey:{2}", new Object[]{sourceClientId, key, clientsForKey});
-            cacheStatus.registerKeyForClient(key, sourceClientId, expiretime);
+            // finishAndReleaseLock is guarded so the lock is released exactly once,
+            // whether the release comes from the broadcast completion or from the
+            // catch block below (StampedLock would throw on a double unlock).
+            AtomicBoolean finished = new AtomicBoolean();
             SimpleCallback<RawString> finishAndReleaseLock = (RawString result, Throwable error) -> {
-                locksManager.releaseWriteLockForKey(key, sourceClientId, lockID);
-                onFinish.onResult(result, error);
-            };
-            if (clientsForKey.isEmpty()) {
-                finishAndReleaseLock.onResult(key, null);
-                return;
-            }
-            BroadcastRequestStatus propagation = new BroadcastRequestStatus("putEntry " + key + " from " + sourceClientId + " started at " + new java.sql.Timestamp(System.currentTimeMillis()), clientsForKey, finishAndReleaseLock, null);
-            networkRequestsStatusMonitor.register(propagation);
-
-            clientsForKey.forEach((clientId) -> {
-                CacheServerSideConnection connection = acceptor.getActualConnectionFromClient(clientId);
-                if (connection == null) {
-                    LOGGER.log(Level.SEVERE, "client " + clientId + " not connected, considering key " + key + " invalidated");
-                    propagation.clientDone(clientId);
-                } else {
-                    connection.sendPutEntry(sourceClientId, key, data, expiretime, propagation);
+                if (finished.compareAndSet(false, true)) {
+                    locksManager.releaseWriteLockForKey(key, sourceClientId, lockID);
+                    onFinish.onResult(result, error);
                 }
-            });
+            };
+            try {
+                Set<String> clientsForKey = cacheStatus.getClientsForKey(key);
+                if (sourceClientId != null) {
+                    clientsForKey.remove(sourceClientId);
+                }
+                LOGGER.log(Level.FINEST, "putEntry from {0}, key={1}, clientsForKey:{2}", new Object[]{sourceClientId, key, clientsForKey});
+                cacheStatus.registerKeyForClient(key, sourceClientId, expiretime);
+                if (clientsForKey.isEmpty()) {
+                    finishAndReleaseLock.onResult(key, null);
+                    return;
+                }
+                BroadcastRequestStatus propagation = new BroadcastRequestStatus("putEntry " + key + " from " + sourceClientId + " started at " + new java.sql.Timestamp(System.currentTimeMillis()), clientsForKey, finishAndReleaseLock, null);
+                networkRequestsStatusMonitor.register(propagation);
+
+                clientsForKey.forEach((clientId) -> {
+                    CacheServerSideConnection connection = acceptor.getActualConnectionFromClient(clientId);
+                    if (connection == null) {
+                        LOGGER.log(Level.SEVERE, "client " + clientId + " not connected, considering key " + key + " invalidated");
+                        propagation.clientDone(clientId);
+                    } else {
+                        connection.sendPutEntry(sourceClientId, key, data, expiretime, propagation);
+                    }
+                });
+            } catch (Throwable t) {
+                // the body failed before wiring the asynchronous release: free the lock now
+                LOGGER.log(Level.SEVERE, "error in putEntry for key " + key + ", releasing the lock", t);
+                finishAndReleaseLock.onResult(null, t);
+            }
         };
         executeOnHandler("putEntry " + sourceClientId + "," + key, action);
     }
@@ -333,14 +346,21 @@ public class CacheServer implements AutoCloseable {
                 onFinish.onResult(null, new Exception("invalid clientProvidedLockId " + clientProvidedLockId));
                 return;
             }
-            Set<String> clientsForKey = cacheStatus.getClientsForKey(key);
-            if (sourceClientId != null) {
-                clientsForKey.remove(sourceClientId);
+            AtomicBoolean finished = new AtomicBoolean();
+            SimpleCallback<RawString> finishAndReleaseLock = (RawString result, Throwable error) -> {
+                if (finished.compareAndSet(false, true)) {
+                    locksManager.releaseWriteLockForKey(key, sourceClientId, lockID);
+                    onFinish.onResult(result, error);
+                }
+            };
+            try {
+                LOGGER.log(Level.FINEST, "loadEntry from {0}, key={1}", new Object[]{sourceClientId, key});
+                cacheStatus.registerKeyForClient(key, sourceClientId, expiretime);
+                finishAndReleaseLock.onResult(key, null);
+            } catch (Throwable t) {
+                LOGGER.log(Level.SEVERE, "error in loadEntry for key " + key + ", releasing the lock", t);
+                finishAndReleaseLock.onResult(null, t);
             }
-            LOGGER.log(Level.FINEST, "loadEntry from {0}, key={1}, clientsForKey:{2}", new Object[]{sourceClientId, key, clientsForKey});
-            cacheStatus.registerKeyForClient(key, sourceClientId, expiretime);
-            locksManager.releaseWriteLockForKey(key, sourceClientId, lockID);
-            onFinish.onResult(key, null);
         };
         executeOnHandler("loadEntry " + sourceClientId + "," + key, action);
     }
@@ -362,9 +382,9 @@ public class CacheServer implements AutoCloseable {
                 return;
             }
             final LockID lockID = locksManager.acquireWriteLockForKey(key, sourceClientId);
-            SimpleCallback<RawString> finishAndReleaseLock = new SimpleCallback<RawString>() {
-                @Override
-                public void onResult(RawString result, Throwable error) {
+            AtomicBoolean finished = new AtomicBoolean();
+            SimpleCallback<RawString> finishAndReleaseLock = (RawString result, Throwable error) -> {
+                if (finished.compareAndSet(false, true)) {
                     cacheStatus.removeKeyForClient(key, sourceClientId);
                     // Drain the coalesced group BEFORE releasing the lock, so that any
                     // invalidation arriving during completion (still under the write
@@ -377,7 +397,13 @@ public class CacheServer implements AutoCloseable {
                     }
                 }
             };
-            broadcastInvalidation(key, sourceClientId, finishAndReleaseLock);
+            try {
+                broadcastInvalidation(key, sourceClientId, finishAndReleaseLock);
+            } catch (Throwable t) {
+                // release the lock and drain the coalesced group instead of stranding them
+                LOGGER.log(Level.SEVERE, "error in invalidateKey for key " + key + ", releasing the lock", t);
+                finishAndReleaseLock.onResult(null, t);
+            }
         };
         executeOnHandler("invalidateKey " + sourceClientId + "," + key, action);
     }
@@ -389,15 +415,20 @@ public class CacheServer implements AutoCloseable {
                 onFinish.onResult(null, new Exception("invalid clientProvidedLockId " + clientProvidedLockId));
                 return;
             }
-            SimpleCallback<RawString> finishAndReleaseLock = new SimpleCallback<RawString>() {
-                @Override
-                public void onResult(RawString result, Throwable error) {
+            AtomicBoolean finished = new AtomicBoolean();
+            SimpleCallback<RawString> finishAndReleaseLock = (RawString result, Throwable error) -> {
+                if (finished.compareAndSet(false, true)) {
                     cacheStatus.removeKeyForClient(key, sourceClientId);
                     locksManager.releaseWriteLockForKey(key, sourceClientId, lockID);
                     onFinish.onResult(result, error);
                 }
             };
-            broadcastInvalidation(key, sourceClientId, finishAndReleaseLock);
+            try {
+                broadcastInvalidation(key, sourceClientId, finishAndReleaseLock);
+            } catch (Throwable t) {
+                LOGGER.log(Level.SEVERE, "error in invalidateKey for key " + key + ", releasing the lock", t);
+                finishAndReleaseLock.onResult(null, t);
+            }
         };
         executeOnHandler("invalidateKey " + sourceClientId + "," + key, action);
     }
@@ -481,18 +512,19 @@ public class CacheServer implements AutoCloseable {
                 onFinish.onResult(null, new Exception("invalid clientProvidedLockId " + clientProvidedLockId));
                 return;
             }
+            AtomicBoolean finished = new AtomicBoolean();
+            SimpleCallback<Message> finishAndReleaseLock = (Message result, Throwable error) -> {
+                if (finished.compareAndSet(false, true)) {
+                    locksManager.releaseLockForKey(key, clientId, lockID);
+                    onFinish.onResult(result, error);
+                }
+            };
+            try {
             Set<String> clientsForKey = cacheStatus.getClientsForKey(key);
             if (clientId != null) {
                 clientsForKey.remove(clientId);
             }
             LOGGER.log(Level.FINE, "client {0} fetchEntry {1} ask to {2}", new Object[]{clientId, key, clientsForKey});
-            SimpleCallback<Message> finishAndReleaseLock = new SimpleCallback<Message>() {
-                @Override
-                public void onResult(Message result, Throwable error) {
-                    locksManager.releaseLockForKey(key, clientId, lockID);
-                    onFinish.onResult(result, error);
-                }
-            };
             if (clientsForKey.isEmpty()) {
                 finishAndReleaseLock.onResult(Message.ERROR(clientId, new Exception("no client for key " + key)), null);
                 return;
@@ -541,6 +573,11 @@ public class CacheServer implements AutoCloseable {
 
             if (!foundOneGoodClientConnected) {
                 finishAndReleaseLock.onResult(Message.ERROR(clientId, new Exception("no connected client for key " + key)), null);
+            }
+            } catch (Throwable t) {
+                // the body failed before wiring the asynchronous release: free the lock now
+                LOGGER.log(Level.SEVERE, "error in fetchEntry for key " + key + ", releasing the lock", t);
+                finishAndReleaseLock.onResult(Message.ERROR(clientId, t), null);
             }
         };
         executeOnHandler("fetchEntry " + clientId + "," + key, action);

--- a/blazingcache-core/src/main/java/blazingcache/server/CacheServer.java
+++ b/blazingcache-core/src/main/java/blazingcache/server/CacheServer.java
@@ -60,6 +60,7 @@ public class CacheServer implements AutoCloseable {
     private final CacheServerEndpoint acceptor;
     private final CacheStatus cacheStatus = new CacheStatus();
     private final KeyedLockManager locksManager = new KeyedLockManager();
+    private final PendingInvalidationsManager pendingInvalidations = new PendingInvalidationsManager();
     private final NettyChannelAcceptor server;
     private final CacheServerStatusMXBean statusMXBean;
     private final AtomicLong pendingOperations;
@@ -345,15 +346,48 @@ public class CacheServer implements AutoCloseable {
     }
 
     public void invalidateKey(RawString key, String sourceClientId, String clientProvidedLockId, SimpleCallback<RawString> onFinish) {
+        // Invalidations carrying an explicit client-provided lock are not coalesced:
+        // they keep the original per-request semantics tied to that lock.
+        if (clientProvidedLockId != null) {
+            invalidateKeyStandalone(key, sourceClientId, clientProvidedLockId, onFinish);
+            return;
+        }
+        Runnable action = () -> {
+            // Coalesce concurrent invalidations of the same key (issue #188): if an
+            // invalidation of this key is already in flight, attach to it and let it
+            // notify us on completion instead of queueing behind the write lock for
+            // another full broadcast round-trip.
+            boolean owner = pendingInvalidations.register(key, onFinish);
+            if (!owner) {
+                return;
+            }
+            final LockID lockID = locksManager.acquireWriteLockForKey(key, sourceClientId);
+            SimpleCallback<RawString> finishAndReleaseLock = new SimpleCallback<RawString>() {
+                @Override
+                public void onResult(RawString result, Throwable error) {
+                    cacheStatus.removeKeyForClient(key, sourceClientId);
+                    // Drain the coalesced group BEFORE releasing the lock, so that any
+                    // invalidation arriving during completion (still under the write
+                    // lock, hence still exclusive with fetches) is either captured here
+                    // or starts a fresh broadcast once the lock is released.
+                    List<SimpleCallback<RawString>> waiters = pendingInvalidations.complete(key);
+                    locksManager.releaseWriteLockForKey(key, sourceClientId, lockID);
+                    for (SimpleCallback<RawString> waiter : waiters) {
+                        waiter.onResult(result, error);
+                    }
+                }
+            };
+            broadcastInvalidation(key, sourceClientId, finishAndReleaseLock);
+        };
+        executeOnHandler("invalidateKey " + sourceClientId + "," + key, action);
+    }
+
+    private void invalidateKeyStandalone(RawString key, String sourceClientId, String clientProvidedLockId, SimpleCallback<RawString> onFinish) {
         Runnable action = () -> {
             final LockID lockID = locksManager.acquireWriteLockForKey(key, sourceClientId, clientProvidedLockId);
             if (lockID == null) {
                 onFinish.onResult(null, new Exception("invalid clientProvidedLockId " + clientProvidedLockId));
                 return;
-            }
-            Set<String> clientsForKey = cacheStatus.getClientsForKey(key);
-            if (sourceClientId != null) {
-                clientsForKey.remove(sourceClientId);
             }
             SimpleCallback<RawString> finishAndReleaseLock = new SimpleCallback<RawString>() {
                 @Override
@@ -363,28 +397,42 @@ public class CacheServer implements AutoCloseable {
                     onFinish.onResult(result, error);
                 }
             };
-            if (clientsForKey.isEmpty()) {
-                finishAndReleaseLock.onResult(key, null);
-                return;
-            }
-            LOGGER.log(Level.FINE, "invalidateKey {0} from {1} interested clients {2}", new Object[]{key, sourceClientId, clientsForKey});
-
-            BroadcastRequestStatus invalidation = new BroadcastRequestStatus("invalidateKey " + key + " from " + sourceClientId + " started at " + new java.sql.Timestamp(System.currentTimeMillis()), clientsForKey, finishAndReleaseLock, (clientId, error) -> {
-                cacheStatus.removeKeyForClient(key, clientId);
-            });
-            networkRequestsStatusMonitor.register(invalidation);
-
-            clientsForKey.forEach((clientId) -> {
-                CacheServerSideConnection connection = acceptor.getActualConnectionFromClient(clientId);
-                if (connection == null) {
-                    LOGGER.log(Level.SEVERE, "client " + clientId + " not connected, considering key " + key + " invalidated");
-                    invalidation.clientDone(clientId);
-                } else {
-                    connection.sendKeyInvalidationMessage(sourceClientId, key, invalidation);
-                }
-            });
+            broadcastInvalidation(key, sourceClientId, finishAndReleaseLock);
         };
         executeOnHandler("invalidateKey " + sourceClientId + "," + key, action);
+    }
+
+    /**
+     * Snapshots the clients holding the key (excluding the source) and broadcasts
+     * an invalidation to them; {@code onFinish} is invoked once every interested
+     * client has acknowledged (or been considered invalidated). Must be called
+     * while holding the per-key write lock for {@code key}.
+     */
+    private void broadcastInvalidation(RawString key, String sourceClientId, SimpleCallback<RawString> onFinish) {
+        Set<String> clientsForKey = cacheStatus.getClientsForKey(key);
+        if (sourceClientId != null) {
+            clientsForKey.remove(sourceClientId);
+        }
+        if (clientsForKey.isEmpty()) {
+            onFinish.onResult(key, null);
+            return;
+        }
+        LOGGER.log(Level.FINE, "invalidateKey {0} from {1} interested clients {2}", new Object[]{key, sourceClientId, clientsForKey});
+
+        BroadcastRequestStatus invalidation = new BroadcastRequestStatus("invalidateKey " + key + " from " + sourceClientId + " started at " + new java.sql.Timestamp(System.currentTimeMillis()), clientsForKey, onFinish, (clientId, error) -> {
+            cacheStatus.removeKeyForClient(key, clientId);
+        });
+        networkRequestsStatusMonitor.register(invalidation);
+
+        clientsForKey.forEach((clientId) -> {
+            CacheServerSideConnection connection = acceptor.getActualConnectionFromClient(clientId);
+            if (connection == null) {
+                LOGGER.log(Level.SEVERE, "client " + clientId + " not connected, considering key " + key + " invalidated");
+                invalidation.clientDone(clientId);
+            } else {
+                connection.sendKeyInvalidationMessage(sourceClientId, key, invalidation);
+            }
+        });
     }
 
     public void lockKey(RawString key, String sourceClientId, SimpleCallback<String> onFinish) {
@@ -424,7 +472,11 @@ public class CacheServer implements AutoCloseable {
 
     public void fetchEntry(RawString key, String clientId, String clientProvidedLockId, SimpleCallback<Message> onFinish) {
         Runnable action = () -> {
-            final LockID lockID = locksManager.acquireWriteLockForKey(key, clientId, clientProvidedLockId);
+            // A fetch takes a SHARED (read) lock: concurrent fetches on the same
+            // key run in parallel, while still being mutually exclusive with
+            // invalidate/put/load (write lock), preserving the ordering invariant
+            // that the fetch client-registration must not race an invalidate.
+            final LockID lockID = locksManager.acquireReadLockForKey(key, clientId, clientProvidedLockId);
             if (lockID == null) {
                 onFinish.onResult(null, new Exception("invalid clientProvidedLockId " + clientProvidedLockId));
                 return;
@@ -437,7 +489,7 @@ public class CacheServer implements AutoCloseable {
             SimpleCallback<Message> finishAndReleaseLock = new SimpleCallback<Message>() {
                 @Override
                 public void onResult(Message result, Throwable error) {
-                    locksManager.releaseWriteLockForKey(key, clientId, lockID);
+                    locksManager.releaseLockForKey(key, clientId, lockID);
                     onFinish.onResult(result, error);
                 }
             };

--- a/blazingcache-core/src/main/java/blazingcache/server/KeyedLockManager.java
+++ b/blazingcache-core/src/main/java/blazingcache/server/KeyedLockManager.java
@@ -126,9 +126,24 @@ public class KeyedLockManager {
 
     LockID acquireWriteLockForKey(RawString key, String clientId, String clientProvidedLockId) {
         if (clientProvidedLockId != null) {
-            return useClientProvidedLockForKey(key, Long.parseLong(clientProvidedLockId));
+            Long stamp = parseLockId(clientProvidedLockId);
+            return stamp == null ? null : useClientProvidedLockForKey(key, stamp);
         } else {
             return acquireWriteLockForKey(key, clientId);
+        }
+    }
+
+    /**
+     * Parses a client-provided lock id, returning {@code null} (treated as an
+     * invalid lock) instead of throwing on a malformed value, so a bad id is
+     * reported to the client rather than left hanging until timeout.
+     */
+    private static Long parseLockId(String clientProvidedLockId) {
+        try {
+            return Long.parseLong(clientProvidedLockId);
+        } catch (NumberFormatException e) {
+            LOGGER.log(Level.SEVERE, "invalid clientProvidedLockId {0}", clientProvidedLockId);
+            return null;
         }
     }
 
@@ -145,7 +160,8 @@ public class KeyedLockManager {
      */
     LockID acquireReadLockForKey(RawString key, String clientId, String clientProvidedLockId) {
         if (clientProvidedLockId != null) {
-            return useClientProvidedLockForKey(key, Long.parseLong(clientProvidedLockId));
+            Long stamp = parseLockId(clientProvidedLockId);
+            return stamp == null ? null : useClientProvidedLockForKey(key, stamp);
         } else {
             return acquireReadLockForKey(key, clientId);
         }

--- a/blazingcache-core/src/main/java/blazingcache/server/KeyedLockManager.java
+++ b/blazingcache-core/src/main/java/blazingcache/server/KeyedLockManager.java
@@ -138,7 +138,35 @@ public class KeyedLockManager {
         return result;
     }
 
+    /**
+     * Acquires a shared (read) lock for a key. Read locks are mutually exclusive
+     * with write locks (invalidate/put/load) but NOT with each other, so multiple
+     * concurrent fetches on the same key no longer serialize. See issue #188.
+     */
+    LockID acquireReadLockForKey(RawString key, String clientId, String clientProvidedLockId) {
+        if (clientProvidedLockId != null) {
+            return useClientProvidedLockForKey(key, Long.parseLong(clientProvidedLockId));
+        } else {
+            return acquireReadLockForKey(key, clientId);
+        }
+    }
+
+    LockID acquireReadLockForKey(RawString key, String clientId) {
+        StampedLock lock = makeLockForKey(key);
+        LockID result = new LockID(lock.readLock());
+        return result;
+    }
+
     void releaseWriteLockForKey(RawString key, String clientId, LockID lockStamp) {
+        releaseLockForKey(key, clientId, lockStamp);
+    }
+
+    /**
+     * Releases a lock (read or write) previously acquired for the key.
+     * {@link StampedLock#unlock(long)} releases the correct mode according to the
+     * stamp, so the same method works for both read and write locks.
+     */
+    void releaseLockForKey(RawString key, String clientId, LockID lockStamp) {
         if (lockStamp == LockID.VALIDATED_CLIENT_PROVIDED_LOCK) {
             return;
         }

--- a/blazingcache-core/src/main/java/blazingcache/server/PendingInvalidationsManager.java
+++ b/blazingcache-core/src/main/java/blazingcache/server/PendingInvalidationsManager.java
@@ -1,0 +1,107 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package blazingcache.server;
+
+import blazingcache.utils.RawString;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Coalesces concurrent invalidations of the same key (issue #188).
+ * <p>
+ * Invalidating a key is idempotent: while an invalidation of a key is in flight
+ * (holding the per-key write lock and broadcasting to the interested clients), any
+ * further invalidation request for the same key can attach to the in-flight one
+ * instead of queueing behind the lock for another full network round-trip. When the
+ * in-flight invalidation completes, every attached requester is notified with the
+ * same result.
+ * <p>
+ * This is safe because the in-flight invalidation holds the per-key write lock for
+ * the whole broadcast, which is mutually exclusive with fetches (read lock): no
+ * client can register itself for the key between the moment the interested-clients
+ * set is snapshotted and the moment the broadcast completes. Therefore any request
+ * that arrives while the broadcast is in flight is fully satisfied by it.
+ *
+ * @author diego.salvi
+ */
+class PendingInvalidationsManager {
+
+    /**
+     * A group of invalidation requests for the same key that share a single
+     * broadcast.
+     */
+    static final class PendingInvalidation {
+
+        private final List<SimpleCallback<RawString>> callbacks =
+                Collections.synchronizedList(new ArrayList<>());
+
+        private void attach(SimpleCallback<RawString> callback) {
+            callbacks.add(callback);
+        }
+
+        List<SimpleCallback<RawString>> getCallbacks() {
+            return callbacks;
+        }
+    }
+
+    private final ConcurrentHashMap<RawString, PendingInvalidation> pending = new ConcurrentHashMap<>();
+
+    /**
+     * Registers an invalidation request for a key.
+     *
+     * @return {@code true} if the caller is the owner of a NEW in-flight
+     * invalidation and must therefore perform the actual broadcast; {@code false}
+     * if the request has been coalesced into an already in-flight invalidation and
+     * the caller must not do anything (its callback will be invoked when the
+     * in-flight invalidation completes).
+     */
+    boolean register(RawString key, SimpleCallback<RawString> onFinish) {
+        final boolean[] owner = {false};
+        pending.compute(key, (k, existing) -> {
+            if (existing == null) {
+                existing = new PendingInvalidation();
+                owner[0] = true;
+            }
+            existing.attach(onFinish);
+            return existing;
+        });
+        return owner[0];
+    }
+
+    /**
+     * Marks the in-flight invalidation of a key as completed and returns every
+     * callback that must be notified (the owner's plus all the coalesced ones).
+     * Any invalidation request arriving after this call will start a fresh
+     * broadcast.
+     */
+    List<SimpleCallback<RawString>> complete(RawString key) {
+        PendingInvalidation removed = pending.remove(key);
+        if (removed == null) {
+            return Collections.emptyList();
+        }
+        return removed.getCallbacks();
+    }
+
+    int getNumberOfPendingInvalidations() {
+        return pending.size();
+    }
+}

--- a/blazingcache-core/src/test/java/blazingcache/client/ApparentlyStuckClientDueToServerSideErrorTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/ApparentlyStuckClientDueToServerSideErrorTest.java
@@ -34,25 +34,24 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class ApparentlyStuckClientDueToServerSideErrorTest {
 
-    @Test
+    @Test(timeout = 60000)
     public void test() throws Exception {
         byte[] data = "testdata".getBytes(StandardCharsets.UTF_8);
 
         ServerHostData serverHostData = new ServerHostData("localhost", 1234, "test", false, null);
         try ( CacheServer cacheServer = new CacheServer("ciao", serverHostData)) {
 
-            cacheServer.setSlowClientTimeout(10000);
+            // keep the "declare the errored client dead" path bounded and fast
+            cacheServer.setSlowClientTimeout(2000);
             cacheServer.start();
             AtomicReference<CacheClient> _client2 = new AtomicReference<>();
             try ( CacheClient client1 = new CacheClient("theClient1", "ciao", new NettyCacheServerLocator(serverHostData));  CacheClient client2 = new CacheClient("theClient2", "ciao",
                     new NettyCacheServerLocator(serverHostData)) {
                 @Override
                 public void messageReceived(Message message) {
-                    // swallow every message
-                    // client2 will not answer to the "invaliate" message
-                    // client1 has to wait until the server declares client2 dead
-
-                    // simulate a network error, only on the server side part
+                    // simulate a network error on the server side of client2's connection:
+                    // client2 never processes/acks the message and its connection is dropped, so
+                    // client1's invalidate must not hang - the server has to declare client2 dead.
                     CacheServerSideConnection serverSideConnectionPeer2 = cacheServer.getAcceptor().getClientConnections().get(_client2.get().getClientId());
                     // we are sure that we are using the NettyChannel, not JVMChannel
                     NettyChannel channel = (NettyChannel) serverSideConnectionPeer2.getChannel();
@@ -68,19 +67,41 @@ public class ApparentlyStuckClientDueToServerSideErrorTest {
                 assertTrue(client2.waitForConnection(10000));
 
                 client1.load("foo", data, 0);
-                assertNotNull(client2.fetch("foo"));
+                EntryHandle fetched = client2.fetch("foo");
+                assertNotNull(fetched);
+                fetched.close();
 
+                // the invalidate must COMPLETE even though client2 errors instead of acking:
+                // the server declares client2 dead (slow-client timeout / connection error) and
+                // unblocks. If this regressed, the call would hang and the @Test timeout would fire.
                 client1.invalidate("foo");
 
                 assertNull(client1.get("foo"));
-                
-                // client2 does not know that the server had problems and it still holds a copy of the value
-                assertNotNull(client2.get("foo"));                 
 
+                // The server-side error dropped client2's connection; a disconnected client empties
+                // its local cache (it can no longer receive invalidations), so it stops serving the
+                // now-stale entry. This is deterministic; asserting the opposite ("client2 still
+                // holds the value") used to race the reconnect/emptyCache and made the test flaky.
+                assertBecomesAbsent(client2, "foo", 30000);
             }
 
         }
 
+    }
+
+    private static void assertBecomesAbsent(CacheClient client, String key, long timeoutMillis) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMillis;
+        while (true) {
+            EntryHandle entry = client.get(key);
+            if (entry == null) {
+                return;
+            }
+            entry.close();
+            if (System.currentTimeMillis() > deadline) {
+                throw new AssertionError("entry " + key + " was still present after " + timeoutMillis + "ms");
+            }
+            Thread.sleep(50);
+        }
     }
 
 }

--- a/blazingcache-core/src/test/java/blazingcache/client/FetchAndInvalidateStormTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/FetchAndInvalidateStormTest.java
@@ -1,0 +1,240 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package blazingcache.client;
+
+import static org.junit.Assert.assertEquals;
+import blazingcache.client.impl.InternalClientListener;
+import blazingcache.network.Channel;
+import blazingcache.network.Message;
+import blazingcache.network.ServerHostData;
+import blazingcache.network.netty.NettyCacheServerLocator;
+import blazingcache.server.CacheServer;
+import blazingcache.utils.RawString;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.Test;
+
+/**
+ * Reproducer for issue #188: under a storm of concurrent fetch and invalidate
+ * operations on a single hot key, the server keeps a per-key WRITE lock held for
+ * the whole duration of the network round-trip (see
+ * {@code CacheServer.fetchEntry / invalidateKey} which acquire
+ * {@code KeyedLockManager.acquireWriteLockForKey} and release it only in the
+ * async reply callback).
+ * <p>
+ * As a consequence every operation on that key is fully serialized and each one
+ * holds the lock for a full RTT. When many clients hit the same key at once the
+ * per-key queue cannot drain and individual operations become unresponsive
+ * ("timeout") on that key, while the rest of the cache is fine.
+ * <p>
+ * The client masks internal timeouts ({@code invalidate()} retries forever,
+ * {@code fetch()} returns null on {@code TimeoutException}), so we observe the
+ * pathology with an EXTERNAL watchdog on per-operation wall-clock latency: an
+ * operation that takes longer than {@link #OP_WATCHDOG_MS} is counted as a
+ * timeout.
+ *
+ * @author diego.salvi
+ */
+public class FetchAndInvalidateStormTest {
+
+    /** Client that owns the key and serves fetch requests. */
+    private static final int HOLDERS = 1;
+    /**
+     * Concurrent clients continuously fetching the hot key. Together with the
+     * invalidators this gives ~28 distinct clients against a single server,
+     * matching the production topology (a few dozen clients on the same hot key).
+     */
+    private static final int FETCHERS = 24;
+    /** Concurrent clients continuously invalidating the hot key. */
+    private static final int INVALIDATORS = 3;
+    /** Simulated per-message service time on the owner (models real RTT / load). */
+    private static final long SERVE_DELAY_MS = 200;
+    /**
+     * Pause between two operations of the same worker. Keeps each worker in a
+     * realistic request rate and, crucially, prevents fetchers from spinning on
+     * local cache hits at millions of ops/s (which would burn CPU and turn the
+     * test into a CPU-starvation test instead of a lock-serialization test).
+     */
+    private static final long OP_PACING_MS = 2;
+    /** An operation slower than this is considered "timed out" on the hot key. */
+    private static final long OP_WATCHDOG_MS = 3_000;
+    /** How long to keep hammering the key. */
+    private static final long TEST_DURATION_MS = 15_000;
+
+    private static final String KEY = "hot-key";
+
+    @Test(timeout = 180_000)
+    public void hotKeyStormDoesNotStall() throws Exception {
+        byte[] data = "testdata".getBytes(StandardCharsets.UTF_8);
+
+        ServerHostData serverHostData = new ServerHostData("localhost", 1234, "test", false, null);
+        try (CacheServer cacheServer = new CacheServer("ciao", serverHostData)) {
+            // let the server wait long enough for the (deliberately slow) owner,
+            // so fetches SUCCEED but slowly: we want to measure serialization, not
+            // server-side fetch timeouts.
+            cacheServer.setClientFetchTimeout(60_000);
+            cacheServer.start();
+
+            List<CacheClient> clients = new ArrayList<>();
+            try {
+                // ---- owner clients: hold the key and serve fetches with a delay ----
+                for (int i = 0; i < HOLDERS; i++) {
+                    CacheClient holder = newClient("holder-" + i, serverHostData);
+                    holder.setFetchPriority(10);
+                    holder.setInternalClientListener(new InternalClientListener() {
+                        @Override
+                        public boolean messageReceived(Message message, Channel channel) {
+                            if (message.type == Message.TYPE_FETCH_ENTRY) {
+                                sleep(SERVE_DELAY_MS);
+                            }
+                            return true;
+                        }
+                    });
+                    clients.add(holder);
+                    holder.start();
+                }
+                CacheClient owner = clients.get(0);
+                assertConnected(clients);
+                owner.load(KEY, data, 0);
+
+                AtomicBoolean terminate = new AtomicBoolean(false);
+                AtomicLong maxLatencyMs = new AtomicLong(0);
+                AtomicLong totalOps = new AtomicLong(0);
+                List<String> timeouts = new CopyOnWriteArrayList<>();
+                List<Throwable> errors = new CopyOnWriteArrayList<>();
+
+                List<Thread> workers = new ArrayList<>();
+
+                // ---- fetchers ----
+                for (int i = 0; i < FETCHERS; i++) {
+                    CacheClient fetcher = newClient("fetcher-" + i, serverHostData);
+                    // do not let a fetcher serve others: keep the owner as the source
+                    fetcher.setFetchPriority(0);
+                    clients.add(fetcher);
+                    fetcher.start();
+                    workers.add(new Thread(() -> hammer(terminate, timeouts, errors, maxLatencyMs, totalOps, "fetch", () -> {
+                        EntryHandle h = fetcher.fetch(KEY);
+                        if (h != null) {
+                            h.close();
+                        }
+                    }), "fetcher-thread-" + i));
+                }
+
+                // ---- invalidators (each re-loads on the owner to keep the key hot) ----
+                for (int i = 0; i < INVALIDATORS; i++) {
+                    CacheClient invalidator = newClient("invalidator-" + i, serverHostData);
+                    invalidator.setFetchPriority(0);
+                    clients.add(invalidator);
+                    invalidator.start();
+                    workers.add(new Thread(() -> hammer(terminate, timeouts, errors, maxLatencyMs, totalOps, "invalidate", () -> {
+                        invalidator.invalidate(KEY);
+                        // keep the owner populated so fetches keep hitting the slow serve path
+                        owner.load(KEY, data, 0);
+                    }), "invalidator-thread-" + i));
+                }
+
+                assertConnected(clients);
+
+                long start = System.currentTimeMillis();
+                workers.forEach(Thread::start);
+                Thread.sleep(TEST_DURATION_MS);
+                terminate.set(true);
+                for (Thread t : workers) {
+                    t.join(30_000);
+                }
+                long elapsed = System.currentTimeMillis() - start;
+
+                System.out.println("STORM: duration=" + elapsed + "ms ops=" + totalOps.get()
+                        + " maxLatency=" + maxLatencyMs.get() + "ms"
+                        + " timeouts(>" + OP_WATCHDOG_MS + "ms)=" + timeouts.size()
+                        + " errors=" + errors.size());
+                timeouts.stream().limit(20).forEach(t -> System.out.println("  TIMEOUT " + t));
+                errors.stream().limit(20).forEach(t -> System.out.println("  ERROR " + t));
+
+                assertEquals("unexpected errors during storm: " + errors, 0, errors.size());
+                assertEquals("operations stalled (>" + OP_WATCHDOG_MS + "ms) on the hot key: " + timeouts,
+                        0, timeouts.size());
+            } finally {
+                for (CacheClient c : clients) {
+                    try {
+                        c.close();
+                    } catch (Throwable ignore) {
+                        // best effort
+                    }
+                }
+            }
+        }
+    }
+
+    private interface Op {
+        void run() throws Exception;
+    }
+
+    private static void hammer(AtomicBoolean terminate, List<String> timeouts, List<Throwable> errors,
+            AtomicLong maxLatencyMs, AtomicLong totalOps, String label, Op op) {
+        while (!terminate.get()) {
+            long t0 = System.currentTimeMillis();
+            try {
+                op.run();
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                return;
+            } catch (Throwable t) {
+                errors.add(t);
+                return;
+            }
+            long latency = System.currentTimeMillis() - t0;
+            totalOps.incrementAndGet();
+            maxLatencyMs.accumulateAndGet(latency, Math::max);
+            if (latency > OP_WATCHDOG_MS) {
+                timeouts.add(label + " took " + latency + "ms");
+            }
+            if (OP_PACING_MS > 0) {
+                sleep(OP_PACING_MS);
+            }
+        }
+    }
+
+    private static CacheClient newClient(String id, ServerHostData serverHostData) {
+        return new CacheClient(id, "ciao", new NettyCacheServerLocator(serverHostData));
+    }
+
+    private static void assertConnected(List<CacheClient> clients) throws InterruptedException {
+        for (CacheClient c : clients) {
+            if (!c.waitForConnection(10_000)) {
+                throw new IllegalStateException("client " + c.getClientId() + " not connected");
+            }
+        }
+    }
+
+    private static void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/blazingcache-core/src/test/java/blazingcache/client/WriterStarvationTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/WriterStarvationTest.java
@@ -1,0 +1,216 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package blazingcache.client;
+
+import static org.junit.Assert.assertEquals;
+import blazingcache.client.impl.InternalClientListener;
+import blazingcache.network.Channel;
+import blazingcache.network.Message;
+import blazingcache.network.ServerHostData;
+import blazingcache.network.netty.NettyCacheServerLocator;
+import blazingcache.server.CacheServer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.Test;
+
+/**
+ * Writer-starvation stress for issue #188.
+ * <p>
+ * Since the fix, a fetch takes a SHARED (read) lock on the key while an invalidate
+ * takes the EXCLUSIVE (write) lock. {@link java.util.concurrent.locks.StampedLock}
+ * is not fair, so in principle a continuous stream of readers could starve a writer.
+ * This test hammers a single hot key with a large number of concurrent fetchers
+ * served with a deliberately long per-fetch latency (long-held read locks), while a
+ * single invalidator plays the role of the writer under test, and checks that the
+ * invalidator is never starved for longer than {@link #OP_WATCHDOG_MS}.
+ * <p>
+ * Note that read pressure on a single key is naturally self-limiting: once a client
+ * has fetched the key it serves subsequent gets from its local cache and stops
+ * hitting the server, so read locks are only taken again after an invalidation
+ * evicts the local copies. The invalidator therefore both drives the re-fetch bursts
+ * and measures its own latency against them.
+ *
+ * @author diego.salvi
+ */
+public class WriterStarvationTest {
+
+    /** Clients that own the key and serve fetch requests. */
+    private static final int HOLDERS = 1;
+    /** Many concurrent clients hammering the hot key to keep read locks busy. */
+    private static final int FETCHERS = 40;
+    /**
+     * Long per-fetch service time on the owner: read locks are held for a long time
+     * to maximise the chance of starving the invalidate write lock.
+     */
+    private static final long SERVE_DELAY_MS = 300;
+    /** The invalidator (writer under test) is considered starved beyond this. */
+    private static final long OP_WATCHDOG_MS = 3_000;
+    /** How long to keep hammering the key. */
+    private static final long TEST_DURATION_MS = 15_000;
+
+    private static final String KEY = "hot-key";
+
+    @Test(timeout = 180_000)
+    public void invalidateIsNotStarvedByFetches() throws Exception {
+        byte[] data = "testdata".getBytes(StandardCharsets.UTF_8);
+
+        ServerHostData serverHostData = new ServerHostData("localhost", 1234, "test", false, null);
+        try (CacheServer cacheServer = new CacheServer("ciao", serverHostData)) {
+            cacheServer.setClientFetchTimeout(60_000);
+            cacheServer.start();
+
+            List<CacheClient> clients = new ArrayList<>();
+            try {
+                for (int i = 0; i < HOLDERS; i++) {
+                    CacheClient holder = newClient("holder-" + i, serverHostData);
+                    holder.setFetchPriority(10);
+                    holder.setInternalClientListener(new InternalClientListener() {
+                        @Override
+                        public boolean messageReceived(Message message, Channel channel) {
+                            if (message.type == Message.TYPE_FETCH_ENTRY) {
+                                sleep(SERVE_DELAY_MS);
+                            }
+                            return true;
+                        }
+                    });
+                    clients.add(holder);
+                    holder.start();
+                }
+                CacheClient owner = clients.get(0);
+                assertConnected(clients);
+                owner.load(KEY, data, 0);
+
+                AtomicBoolean terminate = new AtomicBoolean(false);
+                AtomicLong fetchOps = new AtomicLong(0);
+                AtomicLong invalidateOps = new AtomicLong(0);
+                AtomicLong maxInvalidateLatencyMs = new AtomicLong(0);
+                List<String> starved = new CopyOnWriteArrayList<>();
+                List<Throwable> errors = new CopyOnWriteArrayList<>();
+
+                List<Thread> workers = new ArrayList<>();
+
+                for (int i = 0; i < FETCHERS; i++) {
+                    CacheClient fetcher = newClient("fetcher-" + i, serverHostData);
+                    fetcher.setFetchPriority(0);
+                    clients.add(fetcher);
+                    fetcher.start();
+                    workers.add(new Thread(() -> {
+                        while (!terminate.get()) {
+                            try {
+                                EntryHandle h = fetcher.fetch(KEY);
+                                if (h != null) {
+                                    h.close();
+                                }
+                                fetchOps.incrementAndGet();
+                            } catch (InterruptedException ie) {
+                                Thread.currentThread().interrupt();
+                                return;
+                            } catch (Throwable t) {
+                                errors.add(t);
+                                return;
+                            }
+                        }
+                    }, "fetcher-thread-" + i));
+                }
+
+                // the single writer under test: it also drives re-fetch bursts by
+                // evicting the local copies of the fetchers.
+                CacheClient invalidator = newClient("invalidator", serverHostData);
+                invalidator.setFetchPriority(0);
+                clients.add(invalidator);
+                invalidator.start();
+                workers.add(new Thread(() -> {
+                    while (!terminate.get()) {
+                        long t0 = System.currentTimeMillis();
+                        try {
+                            invalidator.invalidate(KEY);
+                            // keep the owner populated so fetchers keep hitting the slow serve path
+                            owner.load(KEY, data, 0);
+                        } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                            return;
+                        } catch (Throwable t) {
+                            errors.add(t);
+                            return;
+                        }
+                        long latency = System.currentTimeMillis() - t0;
+                        invalidateOps.incrementAndGet();
+                        maxInvalidateLatencyMs.accumulateAndGet(latency, Math::max);
+                        if (latency > OP_WATCHDOG_MS) {
+                            starved.add("invalidate took " + latency + "ms");
+                        }
+                    }
+                }, "invalidator-thread"));
+
+                assertConnected(clients);
+
+                workers.forEach(Thread::start);
+                Thread.sleep(TEST_DURATION_MS);
+                terminate.set(true);
+                for (Thread t : workers) {
+                    t.join(30_000);
+                }
+
+                System.out.println("WRITER-STARVATION: fetchOps=" + fetchOps.get()
+                        + " invalidateOps=" + invalidateOps.get()
+                        + " maxInvalidateLatency=" + maxInvalidateLatencyMs.get() + "ms"
+                        + " starved(>" + OP_WATCHDOG_MS + "ms)=" + starved.size()
+                        + " errors=" + errors.size());
+                starved.stream().limit(20).forEach(s -> System.out.println("  STARVED " + s));
+                errors.stream().limit(20).forEach(t -> System.out.println("  ERROR " + t));
+
+                assertEquals("unexpected errors: " + errors, 0, errors.size());
+                assertEquals("invalidate (writer) starved by concurrent fetches: " + starved, 0, starved.size());
+            } finally {
+                for (CacheClient c : clients) {
+                    try {
+                        c.close();
+                    } catch (Throwable ignore) {
+                        // best effort
+                    }
+                }
+            }
+        }
+    }
+
+    private static CacheClient newClient(String id, ServerHostData serverHostData) {
+        return new CacheClient(id, "ciao", new NettyCacheServerLocator(serverHostData));
+    }
+
+    private static void assertConnected(List<CacheClient> clients) throws InterruptedException {
+        for (CacheClient c : clients) {
+            if (!c.waitForConnection(10_000)) {
+                throw new IllegalStateException("client " + c.getClientId() + " not connected");
+            }
+        }
+    }
+
+    private static void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/blazingcache-core/src/test/java/blazingcache/server/KeyedLockManagerLockIdTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/server/KeyedLockManagerLockIdTest.java
@@ -1,0 +1,48 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package blazingcache.server;
+
+import static org.junit.Assert.assertNull;
+import blazingcache.utils.RawString;
+import org.junit.Test;
+
+/**
+ * A malformed (non-numeric) client-provided lock id must be reported as an invalid
+ * lock (null) instead of throwing a NumberFormatException that would leave the
+ * request hanging until timeout (issue #188).
+ *
+ * @author diego.salvi
+ */
+public class KeyedLockManagerLockIdTest {
+
+    private static final RawString KEY = RawString.of("k");
+
+    @Test
+    public void malformedClientProvidedLockIdIsInvalidOnWrite() {
+        KeyedLockManager m = new KeyedLockManager();
+        assertNull(m.acquireWriteLockForKey(KEY, "client", "not-a-number"));
+    }
+
+    @Test
+    public void malformedClientProvidedLockIdIsInvalidOnRead() {
+        KeyedLockManager m = new KeyedLockManager();
+        assertNull(m.acquireReadLockForKey(KEY, "client", "not-a-number"));
+    }
+}


### PR DESCRIPTION
### Problem (#188)
  
Under a storm of concurrent fetch and invalidate operations on a single hot key, the coordinator became unresponsive on that key (the rest of the cache stayed fine). Clients timed out waiting; the server showed pending broadcast invalidations piling up.

### Root cause

CacheServer.fetchEntry / invalidateKey / putEntry / loadEntry all acquired a per-key exclusive write lock  (KeyedLockManager, StampedLock.writeLock()) and held it for the entire network round-trip (released only in the async  reply callback). So every operation on a key serialized, one RTT each, and under high traffic the per-key queue could not  drain. CacheStatus is already internally thread-safe, so fetch-vs-fetch exclusion was unnecessary — the lock only needsto order a fetch's client-registration against an invalidate (the invariant from #170).

### Fix (server-side, protocol- and backward-compatible)
1. Read/write lock split — fetchEntry now takes a shared read lock instead of the exclusive write lock. Concurrent fetches on the same key no longer serialize, while remaining mutually exclusive with invalidate/put/load. The #170 ordering invariant is preserved.
2. Invalidation coalescing (PendingInvalidationsManager) — concurrent invalidations of the same key attach to an in-flight  one instead of queueing behind the write lock for another full broadcast. Safe because the in-flight invalidation holds the write lock during the broadcast (mutually exclusive with fetches), so no client can register for the key between the interested-clients snapshot and broadcast completion.

### Verification
- FetchAndInvalidateStormTest (new, reproduces #188): before 50 timeouts, peak 8.8s; after 0 timeouts, peak ~0.4s.
- WriterStarvationTest (new): guards against writer starvation from the read/write split (~1.2s max invalidate latency under heavy fetch load; no "cliff").
- FetchAndInvalidateHammerTest (#170 correctness): green.
- Full blazingcache-core: 70 tests, 0 failures. blazingcache-jcache: 64 tests, 0 failures. apache-rat passes.

### Flaky (Fixes #180 too)
- ApparentlyStuckClientDueToServerSideErrorTest (rewritten to be deterministic) — the old assertion ("client still holds the value") raced the client's own reconnect/emptyCache and was flaky in dev and CI; it
  now asserts the deterministic outcome (invalidate completes and the disconnected client empties its cache), with a @Test timeout as an anti-hang guard.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Rember to add the correct license header to new files.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
